### PR TITLE
feat(gru): data-scaling enablers — nested sampling, resumable inputs fix, early stopping, length bucketing

### DIFF
--- a/code/model_trainers/gru_trainer.py
+++ b/code/model_trainers/gru_trainer.py
@@ -861,6 +861,20 @@ class GruTrainer(BaseMultisubjectTrainer):
             xs_full_for_checkpoint = dataset.get_all()["xs"]
             df_for_checkpoint = bundle.raw
 
+            # --- Length-bucketed batching (opt-in via training.length_bucketing) ---
+            # Trim the per-batch unroll to the batch's session length instead of
+            # the global T_max, cutting padding compute. Set on the train dataset
+            # that session-regularized training samples from.
+            if bool(self.training.get("length_bucketing", False)):
+                dataset_train.length_bucketing = True
+                dataset_train.length_bucket_grid = int(
+                    self.training.get("length_bucket_grid", 128)
+                )
+                logger.info(
+                    "Length-bucketed batching enabled (grid=%s)",
+                    dataset_train.length_bucket_grid,
+                )
+
             # --- Early stopping (opt-in via training.early_stopping) ---
             # On trigger we `break` the loop, so finalization (gru_config.json,
             # subject_index_map, checkpoints/index.json, auto held-out fine-tune)

--- a/code/model_trainers/gru_trainer.py
+++ b/code/model_trainers/gru_trainer.py
@@ -861,6 +861,25 @@ class GruTrainer(BaseMultisubjectTrainer):
             xs_full_for_checkpoint = dataset.get_all()["xs"]
             df_for_checkpoint = bundle.raw
 
+            # --- Early stopping (opt-in via training.early_stopping) ---
+            # On trigger we `break` the loop, so finalization (gru_config.json,
+            # subject_index_map, checkpoints/index.json, auto held-out fine-tune)
+            # still runs and the best_eval checkpoint is used downstream.
+            _es_cfg = self.training.get("early_stopping", {}) or {}
+            _es_enabled = bool(_es_cfg.get("enabled", False))
+            _es_metric = str(_es_cfg.get("metric", "eval_likelihood"))
+            _es_min_delta = float(_es_cfg.get("min_delta", 0.0))
+            _es_patience = int(_es_cfg.get("patience", 2))
+            _es_guard = _es_cfg.get("overfit_guard", None)
+            _es_guard = float(_es_guard) if _es_guard is not None else None
+            _es_best = float("-inf")
+            _es_stale = 0
+            if _es_enabled:
+                logger.info(
+                    "Early stopping enabled: metric=%s min_delta=%s patience=%s overfit_guard=%s",
+                    _es_metric, _es_min_delta, _es_patience, _es_guard,
+                )
+
             while steps_completed < args.n_steps:
                 chunk_steps = min(
                     args.checkpoint_every_n_steps,
@@ -1264,6 +1283,30 @@ class GruTrainer(BaseMultisubjectTrainer):
                             steps_completed,
                             exc,
                         )
+
+                # --- Early-stopping check (opt-in; checkpoint already saved above) ---
+                if _es_enabled:
+                    _es_val = (
+                        train_likelihood_ckpt
+                        if _es_metric == "train_likelihood"
+                        else eval_likelihood_ckpt
+                    )
+                    if _es_val is not None:
+                        if _es_val > _es_best + _es_min_delta:
+                            _es_best = _es_val
+                            _es_stale = 0
+                        else:
+                            _es_stale += 1
+                        _es_overfit = (
+                            _es_guard is not None and (_es_best - _es_val) > _es_guard
+                        )
+                        if _es_stale >= _es_patience or _es_overfit:
+                            logger.info(
+                                "Early stopping at step %s: %s=%.4f best=%.4f stale=%d/%d overfit=%s",
+                                steps_completed, _es_metric, _es_val, _es_best,
+                                _es_stale, _es_patience, _es_overfit,
+                            )
+                            break
 
             losses = {
                 "training_loss": np.asarray(all_training_losses, dtype=float),

--- a/code/run_hpc.py
+++ b/code/run_hpc.py
@@ -77,6 +77,12 @@ def main(hydra_config: DictConfig) -> None:
         run_output_base = Path(resumable_output_dir).resolve()
         run_output_base.mkdir(parents=True, exist_ok=True)
         logger.info("Resumable mode: stable run output base %s", run_output_base)
+        # Bring inputs.yaml/inputs/.hydra into the stable base so post-training
+        # analysis (resolve_model_run / auto held-out fine-tuning) can locate the
+        # run — same as the wandb branch below. Without this the held-out fine-tune
+        # fails with "Could not find run inputs at <base>/inputs.yaml". Idempotent
+        # on autoResume (dirs_exist_ok; does not touch outputs/checkpoints).
+        copy_run_to_wandb(run_dir, run_output_base)
     elif wandb_run is not None:
         run_output_base = Path(wandb_run.dir).resolve()
         logger.info("wandb run directory: %s", run_output_base)

--- a/code/tests/test_load_mice_database.py
+++ b/code/tests/test_load_mice_database.py
@@ -124,6 +124,20 @@ class TestPartitionSubjects(unittest.TestCase):
         self.assertNotEqual(a["train_ids"], c["train_ids"])  # different seed -> different
         self.assertEqual(a["heldout_ids"], c["heldout_ids"])  # heldout is seed-independent
 
+    def test_training_sample_is_nested_across_ratios(self):
+        # Permutation-prefix sampling => raising subject_ratio only EXTENDS the
+        # training set, so smaller-D cohorts are subsets of larger-D ones
+        # (required for a clean data-scaling curve). Held-out stays constant.
+        small = self._partition(subject_ratio=0.25, seed=0)
+        mid = self._partition(subject_ratio=0.5, seed=0)
+        full = self._partition(subject_ratio=1.0, seed=0)
+        self.assertTrue(set(small["train_ids"]).issubset(set(mid["train_ids"])))
+        self.assertTrue(set(mid["train_ids"]).issubset(set(full["train_ids"])))
+        # sizes scale with ratio (Coupled pool=20 -> 5/10/20)
+        coupled = lambda p: len(p["per_curriculum"]["Coupled Baiting"]["train"])
+        self.assertEqual((coupled(small), coupled(mid), coupled(full)), (5, 10, 20))
+        self.assertEqual(small["heldout_ids"], full["heldout_ids"])
+
     def test_most_common_task_assignment_with_tiebreak(self):
         # m0: 6 Coupled + 6 Uncoupled Baiting -> tie, broken by task name asc -> Coupled.
         df = _make_session_df(

--- a/code/utils/load_mice_database.py
+++ b/code/utils/load_mice_database.py
@@ -245,9 +245,12 @@ def _partition_subjects(
     )
 
     # Step 6 — seeded ratio sample of the train pool, per curriculum.
-    rng = np.random.default_rng(seed)
+    # Permutation-PREFIX (not rng.choice): each curriculum gets an order seeded
+    # independently of n_take, so raising subject_ratio only EXTENDS the set
+    # (D=10 subset of D=30 ...). Nested cohorts are required for a clean
+    # data-scaling curve; rng.choice(size=n_take) is NOT nested across sizes.
     train_ids: List[str] = []
-    for curriculum in curricula:
+    for idx, curriculum in enumerate(curricula):
         pool = per_curriculum[curriculum]["pool"]
         ratio = ratio_map[curriculum]
         n_take = max(0, min(len(pool), int(round(ratio * len(pool)))))
@@ -259,9 +262,11 @@ def _partition_subjects(
                 len(pool),
             )
         if n_take > 0:
-            sampled_index = set(
-                int(i) for i in rng.choice(len(pool), size=n_take, replace=False)
+            seed_seq = (
+                np.random.SeedSequence([int(seed), idx]) if seed is not None else None
             )
+            order = np.random.default_rng(seed_seq).permutation(len(pool))
+            sampled_index = set(int(i) for i in order[:n_take])
             curr_train = [s for i, s in enumerate(pool) if i in sampled_index]
         else:
             curr_train = []

--- a/code/utils/session_regularized_training.py
+++ b/code/utils/session_regularized_training.py
@@ -29,6 +29,27 @@ def _extract_dataset_arrays(dataset: Any) -> tuple[np.ndarray, np.ndarray]:
     return np.asarray(xs), np.asarray(ys)
 
 
+def _length_bucket_cache(xs_all: np.ndarray, grid: int) -> tuple[list[int], dict[int, np.ndarray], np.ndarray]:
+    """Group session columns into grid-rounded length buckets.
+
+    Padding timesteps are marked by feature 0 < 0 (same convention as
+    ``prepend_session_index_to_multisubject_dataset``). Each session's real
+    length is rounded UP to the next multiple of ``grid`` (capped at T_max);
+    sessions sharing a rounded length form one bucket. Returns the sorted
+    bucket lengths, the column indices per bucket, and per-bucket weights
+    (proportional to #sessions, so sampling stays ~uniform over sessions).
+    """
+    t_max = int(xs_all.shape[0])
+    grid = max(1, int(grid))
+    valid = np.asarray(xs_all[:, :, 0]) >= 0
+    lengths = valid.sum(axis=0).astype(int)
+    rounded = np.minimum(((np.maximum(lengths, 1) + grid - 1) // grid) * grid, t_max)
+    uniq = sorted(int(b) for b in set(rounded.tolist()))
+    pools = {b: np.where(rounded == b)[0] for b in uniq}
+    sizes = np.array([len(pools[b]) for b in uniq], dtype=float)
+    return uniq, pools, sizes / sizes.sum()
+
+
 def _sample_batch(dataset: Any) -> tuple[np.ndarray, np.ndarray]:
     xs_all, ys_all = _extract_dataset_arrays(dataset)
     n_episodes = int(xs_all.shape[1])
@@ -42,16 +63,32 @@ def _sample_batch(dataset: Any) -> tuple[np.ndarray, np.ndarray]:
     if batch_size == 0:
         return xs_all[:, :0], ys_all[:, :0]
 
+    rng = getattr(dataset, "rng", None)
+    use_rng = rng if (rng is not None and hasattr(rng, "choice")) else np.random
+
+    # Length-bucketed sampling (opt-in via dataset.length_bucketing): draw the
+    # batch from a single length bucket and TRIM the unroll to that bucket's
+    # grid-rounded length, so short sessions don't pay the global-T_max padding
+    # cost. Trimming only drops all-padding rows (real length <= bucket length),
+    # so the loss/mask are unaffected. Distinct trims = #buckets (~T_max/grid),
+    # i.e. that many JAX recompiles, amortized over training.
+    if batch_mode == "random" and bool(getattr(dataset, "length_bucketing", False)):
+        grid = int(getattr(dataset, "length_bucket_grid", 128))
+        cache = getattr(dataset, "_length_bucket_cache", None)
+        if cache is None:
+            cache = _length_bucket_cache(xs_all, grid)
+            setattr(dataset, "_length_bucket_cache", cache)
+        uniq, pools, weights = cache
+        bucket = int(use_rng.choice(np.asarray(uniq), p=weights))
+        indices = use_rng.choice(pools[bucket], size=batch_size)
+        return xs_all[:bucket, indices], ys_all[:bucket, indices]
+
     if batch_mode == "rolling":
         current_start = int(getattr(dataset, "_current_start_index", 0))
         indices = np.arange(current_start, current_start + batch_size) % n_episodes
         setattr(dataset, "_current_start_index", (current_start + batch_size) % n_episodes)
     elif batch_mode == "random":
-        rng = getattr(dataset, "rng", None)
-        if rng is not None and hasattr(rng, "choice"):
-            indices = rng.choice(n_episodes, size=batch_size)
-        else:
-            indices = np.random.choice(n_episodes, size=batch_size)
+        indices = use_rng.choice(n_episodes, size=batch_size)
     else:
         raise ValueError(
             f"Unsupported dataset.batch_mode='{batch_mode}' for session-regularized training."


### PR DESCRIPTION
Wrapper improvements developed for the mouse data-scaling study. All are backward-compatible (new behavior is opt-in / default-off), so this is safe to land on the working branch.

- **fix(run_hpc): copy inputs.yaml to stable base in resumable mode** (`b0c7f11`) — in resumable mode (`DISRNN_RESUMABLE_OUTPUT_DIR`), `inputs.yaml` stayed in the hydra run dir, so `auto_heldout_finetune`/`resolve_model_run` failed with "Could not find run inputs". Now copied to the stable base (idempotent on autoResume).
- **feat(mice-select): nested permutation-prefix subject sampling** (`41efc09`) — step 6 of `_partition_subjects` used `rng.choice(size=n_take)`, which is NOT nested across sizes. Permutation-prefix makes raising `subject_ratio` only extend the set (D=10 ⊂ D=30 …) for clean data-scaling curves. Held-out reservation unchanged.
- **feat(gru): opt-in early stopping** (`ebb026d`) — `training.early_stopping {enabled,metric,min_delta,patience,overfit_guard}`. Stops at eval-LL plateau; `break`s so finalization (config/index/subject map + held-out fine-tune) still runs and `best_eval` is used. Default off.
- **feat(gru): opt-in length-bucketed batching** (`55e4bc5`) — `training.length_bucketing`. Draws each batch from one grid-rounded session-length bucket and trims the unroll, cutting ~50-75% padding compute (sessions median ~520 vs T_max ~1200+). No data loss. Default off.

### Benchmark — length bucketing (validated post-merge)

Two identical D≈614 / H128 runs, differing only in `length_bucketing` (W&B project `bench_padding`, `grid=128`), measured from the per-step `train/loss` vs wall-clock `_runtime` series:

| run | steady-state s/step | loss @ matched step |
|-----|--------------------:|---------------------|
| `length_bucketing=false` | 0.72 | — |
| `length_bucketing=true`  | **0.33** | identical to baseline (±0.0015, seed/sampling noise) |

**~2.2x speedup with no learning penalty** — the loss trajectories overlap at every matched step, so bucketing only removes padding compute. (A touch under the ~2.6x padding-waste prediction: grid=128 rounding leaves some padding and there is fixed per-step overhead.) Enabled for the 15-run data-scaling sweep.

disRNN equivalents of early-stopping/length-bucketing are noted as follow-ups (study uses GRU). Tests: gru_trainer suite passes (the one `/results` permission failure is pre-existing/env).