### PR TITLE
feat(wandb): concise run names + resilient init (retry then offline fallback)

### DIFF
--- a/code/training_runner.py
+++ b/code/training_runner.py
@@ -174,15 +174,19 @@ def run_training(hydra_config, wandb_run=None, run_output_dir="/results"):
             logger.info("Updated wandb run name to reflect multisubject mode: %s", new_name)
         wandb_run.config.update({"multisubject": True})
 
-    # Append resolved subject IDs to the wandb run name so rank-based slices
-    # (where subject_ids is null in config) are still identifiable in the UI.
+    # Append the resolved subject COUNT to the wandb run name so rank-based slices
+    # (where subject_ids is null in config) stay identifiable in the UI without a
+    # multi-hundred-ID string. The full list lives in config.resolved_subject_ids.
     resolved_subject_ids = dataset_bundle.metadata.get("subject_ids")
     if wandb_run is not None and resolved_subject_ids is not None:
-        ids_str = "-".join(str(s) for s in resolved_subject_ids)
-        new_name = f"{wandb_run.name}_subjs-{ids_str}" if wandb_run.name else f"subs-{ids_str}"
-        wandb_run.name = new_name
+        n_subj = len(resolved_subject_ids)
+        current_name = wandb_run.name or ""
+        suffix = f"n{n_subj}subj"
+        if suffix not in current_name:  # idempotent across autoResume restarts
+            new_name = f"{current_name}_{suffix}" if current_name else suffix
+            wandb_run.name = new_name
+            logger.info("Updated wandb run name to: %s", new_name)
         wandb_run.config.update({"resolved_subject_ids": list(resolved_subject_ids)})
-        logger.info("Updated wandb run name to: %s", new_name)
 
     heldout_test_data = None
     model_type = getattr(hydra_config.model, "type", None)

--- a/code/utils/run_helpers.py
+++ b/code/utils/run_helpers.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -243,18 +244,46 @@ def start_wandb_run(
     base_tags = wandb_cfg.pop("tags", []) or []
     extra_tags = [hydra_config.data.type, hydra_config.model.type, *_hardware_tags()]
 
-    # Init wandb with merged tags
-    run = wandb.init(
-        **wandb_cfg,
-        config={k: dict_config[k] for k in ("data", "model", "meta") if k in dict_config},
-        tags=base_tags + extra_tags,
-    )
-    
+    # When many tasks launch at once (e.g. a grid sweep), simultaneous wandb.init
+    # calls overwhelm the W&B backend and hit the default 90s init timeout. Spread
+    # the first attempt over a per-run-deterministic window, use a longer timeout,
+    # and retry transient failures with backoff. All knobs are env-overridable.
+    init_timeout = int(os.environ.get("WANDB_INIT_TIMEOUT", "300"))
+    stagger_window = int(os.environ.get("WANDB_INIT_STAGGER", "20"))
+    rid = os.environ.get("WANDB_RUN_ID") or str(wandb_cfg.get("name", "")) or ""
+    rid_offset = sum(ord(c) for c in rid)
+    if stagger_window > 0 and rid:
+        time.sleep(rid_offset % stagger_window)
+
+    settings = wandb.Settings(init_timeout=init_timeout)
+    max_attempts = 5
+    run = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            run = wandb.init(
+                **wandb_cfg,
+                config={k: dict_config[k] for k in ("data", "model", "meta") if k in dict_config},
+                tags=base_tags + extra_tags,
+                settings=settings,
+            )
+            break
+        except Exception as exc:  # transient W&B backend/init failures
+            if attempt == max_attempts:
+                raise
+            backoff = min(120, 10 * 2 ** (attempt - 1)) + (rid_offset % 7)
+            logger.warning(
+                "wandb.init failed (attempt %d/%d): %s; retrying in %ds",
+                attempt, max_attempts, exc, backoff,
+            )
+            time.sleep(backoff)
+
     # Reproducibility / provenance metadata stamped into the W&B config.
+    # allow_val_change so resuming a run after a code bump (WANDB_RESUME=allow with
+    # a new WRAPPER_COMMIT) updates the SHA instead of crashing on a config conflict.
     run.config.update({
         "CO_COMPUTATION_ID": os.environ.get("CO_COMPUTATION_ID"),
         **_code_versions(),
-    })
+    }, allow_val_change=True)
     return run
 
 

--- a/code/utils/run_helpers.py
+++ b/code/utils/run_helpers.py
@@ -294,13 +294,30 @@ def start_wandb_run(
         "tags": base_tags + extra_tags,
     })
 
-    # Reproducibility / provenance metadata stamped into the W&B config.
-    # allow_val_change so resuming a run after a code bump (WANDB_RESUME=allow with
-    # a new WRAPPER_COMMIT) updates the SHA instead of crashing on a config conflict.
-    run.config.update({
+    # Provenance stamped into the W&B config (allow_val_change so a resume after a
+    # code/ref bump updates values instead of raising ConfigError). Two layers:
+    #  - platform-native cross-ref ids (alongside CO_COMPUTATION_ID): Beaker exp/job +
+    #    code SHAs — for jumping to the exact run on each platform.
+    #  - `meta`: our portable, human-readable system (study / variant / launch_id /
+    #    label / config_hash), set by launch_beaker_resumable.py via DISRNN_META_* env —
+    #    consistent across CO / Beaker / AI1 HPC. Merge-safe with any config `meta`.
+    meta_env = {
+        "study": os.environ.get("DISRNN_META_STUDY"),
+        "variant": os.environ.get("DISRNN_META_VARIANT"),
+        "launch_id": os.environ.get("DISRNN_META_LAUNCH_ID"),
+        "label": os.environ.get("DISRNN_META_LABEL"),
+        "config_hash": os.environ.get("DISRNN_META_CONFIG_HASH"),
+    }
+    meta = {**(run.config.get("meta") or {}), **{k: v for k, v in meta_env.items() if v}}
+    provenance = {
         "CO_COMPUTATION_ID": os.environ.get("CO_COMPUTATION_ID"),
+        "BEAKER_EXPERIMENT_ID": os.environ.get("BEAKER_EXPERIMENT_ID"),
+        "BEAKER_JOB_ID": os.environ.get("BEAKER_JOB_ID"),
         **_code_versions(),
-    }, allow_val_change=True)
+    }
+    if meta:
+        provenance["meta"] = meta
+    run.config.update(provenance, allow_val_change=True)
     return run
 
 

--- a/code/utils/run_helpers.py
+++ b/code/utils/run_helpers.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import logging
 import os
+import random
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -233,6 +235,47 @@ def _code_versions() -> dict[str, Optional[str]]:
     }
 
 
+def _init_wandb_with_fallback(init_kwargs: dict) -> wandb.sdk.wandb_run.Run:
+    """``wandb.init`` with bounded jittered retries, then an offline fallback.
+
+    Online run creation hits the W&B backend; when many tasks launch at once (a
+    grid sweep starts all its Beaker tasks together) that handshake can time out.
+    Retry a few times with *random* backoff — the jitter de-correlates simultaneous
+    retries so they don't all collide again — then fall back to ``mode="offline"``
+    so training never blocks on W&B. Offline runs log locally and can be synced to
+    W&B afterward (``wandb sync``). If ``WANDB_MODE`` is already offline/disabled,
+    the first attempt just succeeds locally and the retry/fallback never engages.
+    Knobs: ``WANDB_INIT_ATTEMPTS`` (default 3), ``WANDB_INIT_TIMEOUT`` (default 120).
+    """
+    attempts = int(os.environ.get("WANDB_INIT_ATTEMPTS", "3"))
+    timeout = int(os.environ.get("WANDB_INIT_TIMEOUT", "120"))
+    last_exc: Optional[Exception] = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return wandb.init(**init_kwargs, settings=wandb.Settings(init_timeout=timeout))
+        except Exception as exc:  # online run-creation failed (e.g. CommError timeout)
+            last_exc = exc
+            try:
+                wandb.teardown()  # reset any half-started wandb-core service before retry
+            except Exception:
+                pass
+            if attempt < attempts:
+                delay = random.uniform(5.0, 30.0) * attempt  # jittered, grows per attempt
+                logger.warning(
+                    "wandb.init failed (attempt %d/%d): %s; retrying in %.0fs",
+                    attempt, attempts, exc, delay,
+                )
+                time.sleep(delay)
+    logger.warning(
+        "wandb.init failed after %d attempts (%s); falling back to OFFLINE mode "
+        "(run logged locally under the wandb dir; sync to W&B later)",
+        attempts, last_exc,
+    )
+    return wandb.init(
+        **init_kwargs, settings=wandb.Settings(init_timeout=timeout), mode="offline"
+    )
+
+
 def start_wandb_run(
     hydra_config: DictConfig,
 ) -> Optional[wandb.sdk.wandb_run.Run]:
@@ -243,12 +286,13 @@ def start_wandb_run(
     base_tags = wandb_cfg.pop("tags", []) or []
     extra_tags = [hydra_config.data.type, hydra_config.model.type, *_hardware_tags()]
 
-    # Init wandb with merged tags
-    run = wandb.init(
+    # Init wandb with merged tags, retrying then falling back to offline so training
+    # never blocks on a flaky online run-creation handshake.
+    run = _init_wandb_with_fallback({
         **wandb_cfg,
-        config={k: dict_config[k] for k in ("data", "model", "meta") if k in dict_config},
-        tags=base_tags + extra_tags,
-    )
+        "config": {k: dict_config[k] for k in ("data", "model", "meta") if k in dict_config},
+        "tags": base_tags + extra_tags,
+    })
 
     # Reproducibility / provenance metadata stamped into the W&B config.
     # allow_val_change so resuming a run after a code bump (WANDB_RESUME=allow with

--- a/code/utils/run_helpers.py
+++ b/code/utils/run_helpers.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import subprocess
 import sys
-import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -244,38 +243,12 @@ def start_wandb_run(
     base_tags = wandb_cfg.pop("tags", []) or []
     extra_tags = [hydra_config.data.type, hydra_config.model.type, *_hardware_tags()]
 
-    # When many tasks launch at once (e.g. a grid sweep), simultaneous wandb.init
-    # calls overwhelm the W&B backend and hit the default 90s init timeout. Spread
-    # the first attempt over a per-run-deterministic window, use a longer timeout,
-    # and retry transient failures with backoff. All knobs are env-overridable.
-    init_timeout = int(os.environ.get("WANDB_INIT_TIMEOUT", "300"))
-    stagger_window = int(os.environ.get("WANDB_INIT_STAGGER", "20"))
-    rid = os.environ.get("WANDB_RUN_ID") or str(wandb_cfg.get("name", "")) or ""
-    rid_offset = sum(ord(c) for c in rid)
-    if stagger_window > 0 and rid:
-        time.sleep(rid_offset % stagger_window)
-
-    settings = wandb.Settings(init_timeout=init_timeout)
-    max_attempts = 5
-    run = None
-    for attempt in range(1, max_attempts + 1):
-        try:
-            run = wandb.init(
-                **wandb_cfg,
-                config={k: dict_config[k] for k in ("data", "model", "meta") if k in dict_config},
-                tags=base_tags + extra_tags,
-                settings=settings,
-            )
-            break
-        except Exception as exc:  # transient W&B backend/init failures
-            if attempt == max_attempts:
-                raise
-            backoff = min(120, 10 * 2 ** (attempt - 1)) + (rid_offset % 7)
-            logger.warning(
-                "wandb.init failed (attempt %d/%d): %s; retrying in %ds",
-                attempt, max_attempts, exc, backoff,
-            )
-            time.sleep(backoff)
+    # Init wandb with merged tags
+    run = wandb.init(
+        **wandb_cfg,
+        config={k: dict_config[k] for k in ("data", "model", "meta") if k in dict_config},
+        tags=base_tags + extra_tags,
+    )
 
     # Reproducibility / provenance metadata stamped into the W&B config.
     # allow_val_change so resuming a run after a code bump (WANDB_RESUME=allow with


### PR DESCRIPTION
## W&B: concise run names + resilient init (retry → offline fallback)

Carries the wandb improvements developed during the data-scaling study to the working branch (net **+63/−13** across 2 files; the stagger commit is reverted in-PR, so the net is just the two real changes below).

- **`training_runner.py` — concise run name.** The multisubject run name appended every resolved subject ID (hundreds at large D), producing an unreadable name. Use the subject **count** (`_n<count>subj`); full list stays in `config.resolved_subject_ids`. Idempotent across autoResume restarts.
- **`run_helpers.start_wandb_run` — resilient init.** A grid launch starts all Beaker tasks at once; if online run-creation is flaky, `wandb.init` is retried with **jittered backoff**, then **falls back to `WANDB_MODE=offline`** so training never blocks on W&B (offline runs sync later). No-op when `WANDB_MODE` is already offline/disabled. Knobs: `WANDB_INIT_ATTEMPTS` (3), `WANDB_INIT_TIMEOUT` (120). Also adds `allow_val_change=True` on the code-version config stamp so resuming after a `WRAPPER_REF` bump updates the SHA instead of raising `ConfigError`.

**Context:** the study hit a ~40-min transient cluster→W&B run-creation outage; offline mode was the mitigation. A later test confirmed 14 concurrent online inits succeed fine (it was *not* a concurrency limit), so the retry→offline fallback is the right general safeguard. Post-finish auto-sync was intentionally **not** added (it'd run on the cluster, where the same path may be down).

**Tested:** happy path stays online (~1 s, no retry); forced online failure falls back to offline (~0.4 s); `teardown` between retries is safe; import/syntax clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update — provenance stamping (commit `c2cfbc4`).** `start_wandb_run` now also stamps, into the W&B run config: platform-native **`BEAKER_EXPERIMENT_ID`/`BEAKER_JOB_ID`** (read from Beaker env, beside `CO_COMPUTATION_ID`) and a portable **`meta.{study,variant,launch_id,label,config_hash}`** (from `DISRNN_META_*` env set by the dispatcher launchers) — readable + consistent across CO/Beaker/HPC. Route-agnostic, so it covers both the resumable and native-`wandb agent` launch paths.