### PR TITLE
Study data-scaling law wrapper updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,7 @@ job/user.env
 # Committed data artifacts kept out of source (still available on origin/pck_dev)
 code/*.pkl
 code/resolved_run.json
+
+# Local W&B scratch (run logs + downloaded artifact tables); reproducible from W&B.
+wandb/
+artifacts/

--- a/code/model_trainers/gru_trainer.py
+++ b/code/model_trainers/gru_trainer.py
@@ -1335,10 +1335,15 @@ class GruTrainer(BaseMultisubjectTrainer):
             }
 
         training_time = time.time() - start
+        actual_training_steps = int(args.n_steps)
+        if args.checkpoint_every_n_steps > 0:
+            actual_training_steps = int(steps_completed)
         output["training_time"] = training_time
+        output["training_steps_completed"] = actual_training_steps
+        output["training_steps_requested"] = int(args.n_steps)
         output["checkpoint_every_n_steps"] = int(args.checkpoint_every_n_steps)
         output["session_curriculum"]["final_lambda"] = float(
-            _session_curriculum_lambda_for_step(args.n_steps)
+            _session_curriculum_lambda_for_step(actual_training_steps)
         )
         if checkpoint_records:
             output["checkpoints"] = checkpoint_records
@@ -1353,8 +1358,10 @@ class GruTrainer(BaseMultisubjectTrainer):
         if wandb_run is not None:
             wandb_run.log({"fig/validation_loss_curve": wandb.Image(str(losses_path))})
 
-        final_session_curriculum_lambda = _session_curriculum_lambda_for_step(args.n_steps)
-        final_eval_network = _make_eval_network_for_step(args.n_steps)
+        final_session_curriculum_lambda = _session_curriculum_lambda_for_step(
+            actual_training_steps
+        )
+        final_eval_network = _make_eval_network_for_step(actual_training_steps)
 
         if is_multisubject:
             subject_embedding_fig = self._plot_subject_embedding_state_space(
@@ -1465,14 +1472,16 @@ class GruTrainer(BaseMultisubjectTrainer):
 
         final_output_dir = self.output_dir
         if args.checkpoint_every_n_steps > 0:
-            final_output_dir = self.output_dir / "checkpoints" / f"step_{args.n_steps}"
+            final_output_dir = (
+                self.output_dir / "checkpoints" / f"step_{actual_training_steps}"
+            )
             final_output_dir.mkdir(parents=True, exist_ok=True)
 
         split_summaries: dict[str, Any] | None = None
         if checkpoint_records:
             last_checkpoint = checkpoint_records[-1]
             if (
-                int(last_checkpoint.get("step", -1)) == int(args.n_steps)
+                int(last_checkpoint.get("step", -1)) == int(actual_training_steps)
                 and "split_examples" in last_checkpoint
             ):
                 split_summaries = last_checkpoint["split_examples"]
@@ -1513,7 +1522,10 @@ class GruTrainer(BaseMultisubjectTrainer):
             checkpoint_index_path = checkpoint_root / "index.json"
             checkpoint_index = {
                 "checkpoint_every_n_steps": int(args.checkpoint_every_n_steps),
-                "n_steps": int(args.n_steps),
+                "n_steps": int(actual_training_steps),
+                "requested_n_steps": int(args.n_steps),
+                "completed_steps": int(actual_training_steps),
+                "early_stopped": bool(actual_training_steps < int(args.n_steps)),
                 "count": int(len(checkpoint_records)),
                 "checkpoints": checkpoint_records,
             }

--- a/code/model_trainers/gru_trainer.py
+++ b/code/model_trainers/gru_trainer.py
@@ -886,12 +886,17 @@ class GruTrainer(BaseMultisubjectTrainer):
             _es_patience = int(_es_cfg.get("patience", 2))
             _es_guard = _es_cfg.get("overfit_guard", None)
             _es_guard = float(_es_guard) if _es_guard is not None else None
+            # Only arm the check once step >= start_after_step (default 0 = no gating).
+            # Used to let the session-conditioning curriculum reach lambda=1 and train a
+            # while before early stopping can fire (otherwise it stops in pretrain/warm-up).
+            _es_start_after = int(_es_cfg.get("start_after_step", 0) or 0)
             _es_best = float("-inf")
             _es_stale = 0
             if _es_enabled:
                 logger.info(
-                    "Early stopping enabled: metric=%s min_delta=%s patience=%s overfit_guard=%s",
-                    _es_metric, _es_min_delta, _es_patience, _es_guard,
+                    "Early stopping enabled: metric=%s min_delta=%s patience=%s "
+                    "overfit_guard=%s start_after_step=%s",
+                    _es_metric, _es_min_delta, _es_patience, _es_guard, _es_start_after,
                 )
 
             while steps_completed < args.n_steps:
@@ -1299,7 +1304,9 @@ class GruTrainer(BaseMultisubjectTrainer):
                         )
 
                 # --- Early-stopping check (opt-in; checkpoint already saved above) ---
-                if _es_enabled:
+                # Gated: only arm once steps_completed >= start_after_step, so the
+                # session-conditioning curriculum reaches lambda=1 (+ buffer) first.
+                if _es_enabled and steps_completed >= _es_start_after:
                     _es_val = (
                         train_likelihood_ckpt
                         if _es_metric == "train_likelihood"

--- a/code/post_training_analysis/generative_analysis.py
+++ b/code/post_training_analysis/generative_analysis.py
@@ -1565,10 +1565,16 @@ def _compute_and_save_partitioned_post_training_outputs(
             partition_simulated_sessions = simulated_sessions
         else:
             allowed_session_ids = manifest[f"{partition}_session_ids"]
+            # The split manifest is in the SOURCE session namespace (e.g.
+            # "632105_2022-07-16_162930"). Multisubject animal rows are aligned
+            # to the MERGED/training namespace ("632105__632105_..."), so match
+            # them on source_ses_idx (like simulated) — matching on ses_idx
+            # silently dropped every animal session in train/eval. Falls back to
+            # ses_idx when no source id is present (non-aligned/single-subject).
             partition_animal_sessions = _filter_session_rows_by_session_ids(
                 animal_sessions,
                 allowed_session_ids=allowed_session_ids,
-                prefer_source_session_ids=False,
+                prefer_source_session_ids=True,
             )
             partition_simulated_sessions = _filter_session_rows_by_session_ids(
                 simulated_sessions,

--- a/code/post_training_analysis/generative_analysis.py
+++ b/code/post_training_analysis/generative_analysis.py
@@ -17,6 +17,7 @@ import math
 import os
 import pickle
 import random
+import re
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -5481,33 +5482,37 @@ def _build_curriculum_matched_task(
     n_trials: int,
     seed: int,
 ):
+    # IMPORTANT LIMITATION (TODO): this matches only the curriculum *family*
+    # (coupled/uncoupled + baiting) and builds the task with the gym's DEFAULT
+    # block/reward parameters. It does NOT use the session's stage-specific task
+    # parameters (current_stage_actual is logged but unused), so a curriculum
+    # that spans multiple stages -- each with its own reward probs / block
+    # structure / sometimes a different task -- is collapsed into one generic
+    # task. The real per-(curriculum, stage) parameters live in
+    #   https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training
+    # Faithfully reproducing them is tracked in studies/data-scaling-law/
+    # FUTURE_DIRECTIONS.md. Match on normalized family substrings so curriculum
+    # *version* variants (e.g. "UnCoupledBaiting2p3Curriculum") resolve too.
     task_mod = importlib.import_module("aind_behavior_gym.dynamic_foraging.task")
-    curriculum = str(curriculum_name) if curriculum_name is not None else "None"
-    if curriculum == "Uncoupled Baiting":
+    raw = str(curriculum_name) if curriculum_name is not None else "None"
+    norm = re.sub(r"[^a-z0-9]", "", raw.lower())
+    if norm in ("", "none"):
         return task_mod.UncoupledBlockTask(
-            reward_baiting=True,
-            num_trials=int(n_trials),
-            seed=int(seed),
+            reward_baiting=True, num_trials=int(n_trials), seed=int(seed)
         )
-    if curriculum == "Uncoupled Without Baiting":
+    baiting = "withoutbaiting" not in norm and "nobaiting" not in norm
+    if "uncoupled" in norm:
         return task_mod.UncoupledBlockTask(
-            reward_baiting=False,
-            num_trials=int(n_trials),
-            seed=int(seed),
+            reward_baiting=baiting, num_trials=int(n_trials), seed=int(seed)
         )
-    if curriculum == "Coupled Baiting":
+    if "coupled" in norm:  # uncoupled already handled above
         return task_mod.CoupledBlockTask(
-            reward_baiting=True,
-            num_trials=int(n_trials),
-            seed=int(seed),
+            reward_baiting=baiting, num_trials=int(n_trials), seed=int(seed)
         )
-    if curriculum == "None":
-        return task_mod.UncoupledBlockTask(
-            reward_baiting=True,
-            num_trials=int(n_trials),
-            seed=int(seed),
-        )
-    raise ValueError(f"Unsupported curriculum_name={curriculum_name!r}")
+    raise ValueError(
+        f"Unsupported curriculum_name={curriculum_name!r} "
+        "(no coupled/uncoupled family match)"
+    )
 
 
 def _step_task_reward(task: Any, action: int) -> float:

--- a/code/post_training_analysis/generative_analysis.py
+++ b/code/post_training_analysis/generative_analysis.py
@@ -506,6 +506,80 @@ def load_animal_session_history(
     return session_history
 
 
+def _run_batched_rollout(runner, lanes, *, n_actions: int):
+    """Roll out every lane in ``lanes`` in lockstep, batching the model step
+    across lanes.
+
+    Each ``lane`` is a dict with keys ``subject_id``, ``model_ses_idx``,
+    ``source_ses_idx``, ``curriculum_name``, ``n_trials`` and ``seed``. Lanes
+    are mutually independent, so we advance them together over trial index and
+    call ``runner.step_batch`` once per trial for the whole batch — instead of
+    the old per-lane loop that called the model at batch size 1, once per
+    (lane, trial). Every lane keeps its own seeded RNG and curriculum-matched
+    task and is sampled only while ``t < n_trials``, so its (choice, reward)
+    history is identical to a sequential per-lane rollout; only the model step
+    is batched. Returns ``(choice_histories, reward_histories)`` aligned with
+    ``lanes``.
+    """
+    np = _import_dependency("numpy")
+    n_lanes = len(lanes)
+    if n_lanes == 0:
+        return [], []
+    max_trials = max(int(lane["n_trials"]) for lane in lanes)
+
+    tasks: list[Any] = []
+    rngs: list[Any] = []
+    prefixes: list[list[float]] = []
+    for lane in lanes:
+        task = _build_curriculum_matched_task(
+            curriculum_name=lane["curriculum_name"],
+            n_trials=int(lane["n_trials"]),
+            seed=int(lane["seed"]),
+        )
+        if hasattr(task, "reset"):
+            task.reset()
+        tasks.append(task)
+        rngs.append(np.random.default_rng(int(lane["seed"])))
+        # encode_inputs returns [*static_prefix, prev_choice, prev_reward]; the
+        # prefix (subject/session indices) is constant across trials, so build
+        # it once and only mutate the trailing [prev_choice, prev_reward].
+        if hasattr(runner, "encode_inputs"):
+            encoded = runner.encode_inputs(
+                lane["subject_id"],
+                lane["model_ses_idx"],
+                [0.0, 0.0],
+                source_session_id=lane["source_ses_idx"],
+            )
+        else:
+            encoded = [0.0, 0.0]
+        prefixes.append([float(value) for value in encoded[:-2]])
+
+    prefix_width = len(prefixes[0])
+    inputs_np = np.full((n_lanes, prefix_width + 2), -1.0, dtype=np.float32)
+    for lane_index in range(n_lanes):
+        if prefix_width:
+            inputs_np[lane_index, :prefix_width] = prefixes[lane_index]
+
+    choice_histories: list[list[float]] = [[] for _ in range(n_lanes)]
+    reward_histories: list[list[float]] = [[] for _ in range(n_lanes)]
+    state = runner.initial_state_batch(n_lanes)
+
+    for trial_index in range(max_trials):
+        logits_batch, state = runner.step_batch(inputs_np, state)
+        for lane_index in range(n_lanes):
+            if trial_index >= int(lanes[lane_index]["n_trials"]):
+                continue  # finished lane: leave its RNG/history untouched
+            probs = _softmax(logits_batch[lane_index])
+            choice = int(rngs[lane_index].choice(n_actions, p=probs))
+            reward = _step_task_reward(tasks[lane_index], choice)
+            choice_histories[lane_index].append(float(choice))
+            reward_histories[lane_index].append(float(reward))
+            inputs_np[lane_index, -2] = float(choice)
+            inputs_np[lane_index, -1] = float(reward)
+
+    return choice_histories, reward_histories
+
+
 def simulate_model_sessions(
     resolved_run: ResolvedModelRun | Mapping[str, Any],
     animal_sessions,
@@ -559,119 +633,101 @@ def simulate_model_sessions(
         normalized_rollout_mode,
     )
 
-    records = []
-    completed_rollouts = 0
+    # Sessions (rollouts) are mutually independent. The previous implementation
+    # looped per session and called ``runner.step`` at batch size 1, once per
+    # (session, trial) — ~n_sessions * n_trials sequential model dispatches,
+    # dominated by per-call host/device-sync overhead rather than compute.
+    # Instead we advance every lane (= one requested rollout) in lockstep and
+    # batch the model step across lanes (one dispatch per trial for the whole
+    # batch). Each lane keeps its own seeded RNG and curriculum-matched task, so
+    # the produced histories match the per-session loop; only the step is
+    # batched. Lanes are chunked to bound memory at large D.
+    BATCHED_ROLLOUT_CHUNK = 4096
+
+    lanes = []
     for session_index, animal_row in enumerate(animal_rows, start=1):
         model_ses_idx = str(animal_row.get("ses_idx"))
         source_ses_idx = _coalesce_session_identifier(
             animal_row.get("source_ses_idx"),
             fallback=model_ses_idx,
         )
-        subject_id = _normalize_identifier(animal_row.get("subject_id"))
-        session_date = str(animal_row.get("session_date"))
-        curriculum_name = animal_row.get("curriculum_name")
-        current_stage_actual = animal_row.get("current_stage_actual")
-        nwb_suffix = animal_row.get("nwb_suffix")
-        nwb_name = animal_row.get("nwb_name")
         n_trials = int(animal_row.get("n_trials", 0))
         if n_trials <= 0:
             logger.info(
                 "Skipping session %d/%d: subject=%s ses_idx=%s has n_trials=%s",
                 session_index,
                 total_source_sessions,
-                subject_id,
+                _normalize_identifier(animal_row.get("subject_id")),
                 model_ses_idx,
                 animal_row.get("n_trials"),
             )
             continue
-
-        logger.info(
-            "Simulating session %d/%d: subject=%s ses_idx=%s source_ses_idx=%s curriculum=%s n_trials=%d "
-            "(%d rollout%s)",
-            session_index,
-            total_source_sessions,
-            subject_id,
-            model_ses_idx,
-            source_ses_idx,
-            curriculum_name,
-            n_trials,
-            int(n_rollouts_per_session),
-            "" if int(n_rollouts_per_session) == 1 else "s",
-        )
         for rollout_index in range(int(n_rollouts_per_session)):
-            random_seed = _derive_session_seed(
-                run.seed,
-                source_ses_idx,
-                rollout_index=rollout_index,
+            lanes.append(
+                {
+                    "subject_id": _normalize_identifier(animal_row.get("subject_id")),
+                    "model_ses_idx": model_ses_idx,
+                    "source_ses_idx": source_ses_idx,
+                    "session_date": str(animal_row.get("session_date")),
+                    "curriculum_name": animal_row.get("curriculum_name"),
+                    "current_stage_actual": animal_row.get("current_stage_actual"),
+                    "nwb_suffix": animal_row.get("nwb_suffix"),
+                    "nwb_name": animal_row.get("nwb_name"),
+                    "n_trials": n_trials,
+                    "rollout_index": rollout_index,
+                    "seed": _derive_session_seed(
+                        run.seed, source_ses_idx, rollout_index=rollout_index
+                    ),
+                }
             )
-            task = _build_curriculum_matched_task(
-                curriculum_name=curriculum_name,
-                n_trials=n_trials,
-                seed=random_seed,
-            )
-            if hasattr(task, "reset"):
-                task.reset()
 
-            state = copy.deepcopy(runner.initial_state)
-            rng = np.random.default_rng(random_seed)
-            prev_choice = -1.0
-            prev_reward = -1.0
-            choice_history: list[float] = []
-            reward_history: list[float] = []
-
-            for _ in range(n_trials):
-                model_inputs = (
-                    runner.encode_inputs(
-                        subject_id,
-                        model_ses_idx,
-                        [prev_choice, prev_reward],
-                        source_session_id=source_ses_idx,
-                    )
-                    if hasattr(runner, "encode_inputs")
-                    else [prev_choice, prev_reward]
-                )
-                logits, state = runner.step(model_inputs, state)
-                probs = _softmax(logits)
-                choice = int(rng.choice(runner.n_actions, p=probs))
-                reward = _step_task_reward(task, choice)
-
-                choice_history.append(float(choice))
-                reward_history.append(float(reward))
-                prev_choice = float(choice)
-                prev_reward = float(reward)
-
+    records = []
+    completed_rollouts = 0
+    for chunk_start in range(0, len(lanes), BATCHED_ROLLOUT_CHUNK):
+        chunk = lanes[chunk_start : chunk_start + BATCHED_ROLLOUT_CHUNK]
+        max_trials = max(lane["n_trials"] for lane in chunk)
+        logger.info(
+            "Simulating lanes %d-%d/%d (batched rollout): max_trials=%d",
+            chunk_start + 1,
+            chunk_start + len(chunk),
+            len(lanes),
+            max_trials,
+        )
+        choice_histories, reward_histories = _run_batched_rollout(
+            runner, chunk, n_actions=runner.n_actions
+        )
+        for lane_index, lane in enumerate(chunk):
             if int(n_rollouts_per_session) == 1:
-                simulated_ses_idx = source_ses_idx
+                simulated_ses_idx = lane["source_ses_idx"]
             else:
-                simulated_ses_idx = f"{source_ses_idx}__rollout_{rollout_index}"
-
+                simulated_ses_idx = (
+                    f"{lane['source_ses_idx']}__rollout_{lane['rollout_index']}"
+                )
             records.append(
                 {
-                    "subject_id": subject_id,
+                    "subject_id": lane["subject_id"],
                     "ses_idx": simulated_ses_idx,
-                    "source_ses_idx": source_ses_idx,
-                    "session_date": session_date,
-                    "curriculum_name": curriculum_name,
-                    "current_stage_actual": current_stage_actual,
-                    "n_trials": n_trials,
-                    "choice_history": choice_history,
-                    "reward_history": reward_history,
-                    "nwb_suffix": nwb_suffix,
-                    "nwb_name": nwb_name,
-                    "random_seed": int(random_seed),
+                    "source_ses_idx": lane["source_ses_idx"],
+                    "session_date": lane["session_date"],
+                    "curriculum_name": lane["curriculum_name"],
+                    "current_stage_actual": lane["current_stage_actual"],
+                    "n_trials": lane["n_trials"],
+                    "choice_history": choice_histories[lane_index],
+                    "reward_history": reward_histories[lane_index],
+                    "nwb_suffix": lane["nwb_suffix"],
+                    "nwb_name": lane["nwb_name"],
+                    "random_seed": int(lane["seed"]),
                     "model_dir": run.model_dir,
                     "checkpoint_step": run.checkpoint_step,
                     "rollout_mode": normalized_rollout_mode,
                 }
             )
             completed_rollouts += 1
-            logger.info(
-                "Completed rollout %d/%d for ses_idx=%s seed=%d",
-                completed_rollouts,
-                total_requested_rollouts,
-                simulated_ses_idx,
-                int(random_seed),
-            )
+        logger.info(
+            "Completed %d/%d rollouts (batched).",
+            completed_rollouts,
+            total_requested_rollouts,
+        )
 
     logger.info(
         "Finished model simulation: generated %d simulated session%s from %d source session%s.",
@@ -5374,6 +5430,31 @@ def _restore_model_runner(resolved_run: ResolvedModelRun):
                 raise ValueError(
                     "Model output logits width does not match n_actions: "
                     f"{action_logits.shape[0]} vs {self.n_actions}."
+                )
+            return action_logits, next_state
+
+        def initial_state_batch(self, batch_size: int):
+            """Batch-`batch_size` initial state: tile the batch-1 state. Lanes
+            start identical and evolve independently (RNN state has no
+            cross-batch coupling)."""
+            return jax.tree_util.tree_map(
+                lambda leaf: jnp.repeat(leaf, int(batch_size), axis=0),
+                self.initial_state,
+            )
+
+        def step_batch(self, inputs_2d, prev_state):
+            """Batched analogue of ``step``: ``inputs_2d`` is (B, input_dim);
+            returns (B, n_actions) logits and the batched next state. The RNN
+            core applies independently across the batch, so row ``b`` is
+            identical to a separate batch-1 ``step`` on lane ``b`` — batching
+            only amortizes the per-trial dispatch/host-sync over the batch."""
+            input_array = jnp.asarray(inputs_2d, dtype=jnp.float32)
+            logits, next_state = step_transform.apply(params, input_array, prev_state)
+            action_logits = np.asarray(logits)[:, : self.n_actions]
+            if int(action_logits.shape[1]) != self.n_actions:
+                raise ValueError(
+                    "Model output logits width does not match n_actions: "
+                    f"{action_logits.shape[1]} vs {self.n_actions}."
                 )
             return action_logits, next_state
 

--- a/code/post_training_analysis/generative_analysis.py
+++ b/code/post_training_analysis/generative_analysis.py
@@ -14,6 +14,7 @@ import importlib
 import json
 import logging
 import math
+import os
 import pickle
 import random
 import time
@@ -641,8 +642,11 @@ def simulate_model_sessions(
     # batch the model step across lanes (one dispatch per trial for the whole
     # batch). Each lane keeps its own seeded RNG and curriculum-matched task, so
     # the produced histories match the per-session loop; only the step is
-    # batched. Lanes are chunked to bound memory at large D.
-    BATCHED_ROLLOUT_CHUNK = 4096
+    # batched. Lanes are chunked to bound memory at large D. The chunk size is
+    # overridable via DISRNN_GENERATIVE_ROLLOUT_CHUNK (chunk=1 reproduces the
+    # old per-session batch-1 path bit-for-bit; larger trades reproducibility
+    # against speed, since batched matmul differs from batch-1 at the last bit).
+    BATCHED_ROLLOUT_CHUNK = int(os.environ.get("DISRNN_GENERATIVE_ROLLOUT_CHUNK", "4096"))
 
     lanes = []
     for session_index, animal_row in enumerate(animal_rows, start=1):

--- a/code/post_training_analysis/generative_analysis.py
+++ b/code/post_training_analysis/generative_analysis.py
@@ -36,7 +36,9 @@ _DEFAULT_HISTORY_MAX_TRIALS_BACK = 3
 _DEFAULT_HISTORY_AGGREGATE_MIN_TRIALS = 10
 _DEFAULT_HISTORY_SUBJECT_MIN_TRIALS = 5
 _SUBJECT_LEVEL_MIN_ANIMAL_N = 5
-_DEFAULT_SUBJECT_BOOTSTRAP_RESAMPLES = 1000
+_DEFAULT_SUBJECT_BOOTSTRAP_RESAMPLES = int(
+    os.environ.get("DISRNN_SUBJECT_BOOTSTRAP_RESAMPLES", "250")
+)  # 250 gives fine subject-level CIs at a fraction of the 1000-resample cost
 _DEFAULT_SUBJECT_BOOTSTRAP_SEED = 0
 _REWARD_CONDITIONS = ("rewarded", "unrewarded")
 _RUN_LENGTH_CONDITIONS = ("run_length_1", "run_length_gt1")
@@ -1539,6 +1541,20 @@ def _count_session_rows(session_rows) -> int:
     return sum(1 for _ in _iter_session_records(session_rows))
 
 
+def _parallel_partition_worker(task):
+    """Spawn-pool worker: run the unchanged per-partition pipeline for one
+    partition. Returns ``(partition, result)`` — bit-identical to serial."""
+    os.environ.setdefault("MPLBACKEND", "Agg")  # headless figure rendering in workers
+    partition, partition_animal_sessions, partition_simulated_sessions, output_dir, common = task
+    result = _compute_and_save_post_training_outputs(
+        animal_sessions=partition_animal_sessions,
+        simulated_sessions=partition_simulated_sessions,
+        output_dir=output_dir,
+        **common,
+    )
+    return partition, result
+
+
 def _compute_and_save_partitioned_post_training_outputs(
     *,
     animal_sessions,
@@ -1557,41 +1573,81 @@ def _compute_and_save_partitioned_post_training_outputs(
     resolved_run_path = analysis_output_dir / "resolved_run.json"
     resolved_run_path.write_text(json.dumps(resolved_run.to_dict(), indent=2))
 
-    partition_results: dict[str, Any] = {}
-    partition_summary: dict[str, Any] = {}
+    # Slice each partition's sessions up front (cheap; per-session frames). The
+    # split manifest is in the SOURCE session namespace (e.g.
+    # "632105_2022-07-16_162930"); multisubject animal rows are aligned to the
+    # MERGED namespace ("632105__632105_..."), so match animal on source_ses_idx
+    # (like simulated) — matching on ses_idx silently dropped all train/eval
+    # animal sessions.
+    partition_slices: dict[str, tuple[Any, Any]] = {}
     for partition in session_partitions:
         if partition == _SESSION_PARTITION_COMBINED:
-            partition_animal_sessions = animal_sessions
-            partition_simulated_sessions = simulated_sessions
+            partition_slices[partition] = (animal_sessions, simulated_sessions)
         else:
             allowed_session_ids = manifest[f"{partition}_session_ids"]
-            # The split manifest is in the SOURCE session namespace (e.g.
-            # "632105_2022-07-16_162930"). Multisubject animal rows are aligned
-            # to the MERGED/training namespace ("632105__632105_..."), so match
-            # them on source_ses_idx (like simulated) — matching on ses_idx
-            # silently dropped every animal session in train/eval. Falls back to
-            # ses_idx when no source id is present (non-aligned/single-subject).
-            partition_animal_sessions = _filter_session_rows_by_session_ids(
-                animal_sessions,
-                allowed_session_ids=allowed_session_ids,
-                prefer_source_session_ids=True,
-            )
-            partition_simulated_sessions = _filter_session_rows_by_session_ids(
-                simulated_sessions,
-                allowed_session_ids=allowed_session_ids,
-                prefer_source_session_ids=True,
+            partition_slices[partition] = (
+                _filter_session_rows_by_session_ids(
+                    animal_sessions,
+                    allowed_session_ids=allowed_session_ids,
+                    prefer_source_session_ids=True,
+                ),
+                _filter_session_rows_by_session_ids(
+                    simulated_sessions,
+                    allowed_session_ids=allowed_session_ids,
+                    prefer_source_session_ids=True,
+                ),
             )
 
-        partition_result = _compute_and_save_post_training_outputs(
-            animal_sessions=partition_animal_sessions,
-            simulated_sessions=partition_simulated_sessions,
-            output_dir=analysis_output_dir / partition,
-            resolved_run=resolved_run,
-            window_size=window_size,
-            save_animal_session_history=save_animal_session_history,
-        )
+    # Partitions are independent whole computations, so compute them
+    # concurrently — each worker runs the unchanged per-partition pipeline, so
+    # outputs are bit-identical to serial; only scheduling is parallel. Use
+    # 'spawn' (NOT fork): this runs right after the JAX/GPU rollout and forking a
+    # CUDA-initialised process can hang. DISRNN_GENERATIVE_STATS_WORKERS=1 forces
+    # serial (used by the in-process-mock unit tests); the launcher sets it >1.
+    common = dict(
+        resolved_run=resolved_run,
+        window_size=window_size,
+        save_animal_session_history=save_animal_session_history,
+    )
+    max_workers = int(os.environ.get("DISRNN_GENERATIVE_STATS_WORKERS", "1"))
+    partition_results: dict[str, Any] = {}
+    if max_workers > 1 and len(session_partitions) > 1:
+        import concurrent.futures
+        import multiprocessing
+
+        tasks = [
+            (
+                partition,
+                partition_slices[partition][0],
+                partition_slices[partition][1],
+                str(analysis_output_dir / partition),
+                common,
+            )
+            for partition in session_partitions
+        ]
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=min(max_workers, len(tasks)),
+            mp_context=multiprocessing.get_context("spawn"),
+        ) as executor:
+            for partition, partition_result in executor.map(
+                _parallel_partition_worker, tasks
+            ):
+                partition_results[partition] = partition_result
+    else:
+        for partition in session_partitions:
+            partition_animal_sessions, partition_simulated_sessions = partition_slices[partition]
+            partition_results[partition] = _compute_and_save_post_training_outputs(
+                animal_sessions=partition_animal_sessions,
+                simulated_sessions=partition_simulated_sessions,
+                output_dir=analysis_output_dir / partition,
+                **common,
+            )
+
+    partition_summary: dict[str, Any] = {}
+    for partition in session_partitions:
+        partition_result = partition_results[partition]
         partition_result["session_partition"] = partition
-        partition_results[partition] = partition_result
+        partition_animal_sessions, partition_simulated_sessions = partition_slices[partition]
         partition_summary[partition] = {
             "output_dir": partition_result["output_dir"],
             "num_animal_sessions": _count_session_rows(partition_animal_sessions),

--- a/code/post_training_analysis/heldout_finetuning.py
+++ b/code/post_training_analysis/heldout_finetuning.py
@@ -10,6 +10,7 @@ does not import it (the lazy gateway defers it until called).
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import logging
 from dataclasses import asdict
@@ -234,11 +235,23 @@ def _maybe_start_wandb_run(
     source_wandb_cfg = _normalize_mapping(_normalize_mapping(source_run.run_config).get("wandb"))
     default_name = source_wandb_cfg.get("name") or run_dir.name
     init_kwargs.setdefault("name", str(default_name))
-    return wandb.init(
-        **init_kwargs,
-        config=resolved_config,
-        tags=tags,
+    from utils.run_helpers import _init_wandb_with_fallback
+
+    return _init_wandb_with_fallback(
+        {
+            **init_kwargs,
+            "config": resolved_config,
+            "tags": tags,
+        }
     )
+
+
+def _heldout_subject_run_name_suffix(heldout_subject_ids: Sequence[Any]) -> str:
+    if not heldout_subject_ids:
+        return ""
+    encoded_ids = "\0".join(str(subject_id) for subject_id in heldout_subject_ids)
+    digest = hashlib.sha1(encoded_ids.encode("utf-8")).hexdigest()[:8]
+    return f"heldout-n{len(heldout_subject_ids)}-{digest}"
 
 
 def _update_wandb_run_name_for_heldout_subjects(
@@ -251,8 +264,8 @@ def _update_wandb_run_name_for_heldout_subjects(
     configured_name = _normalize_mapping(resolved_config.get("wandb")).get("name")
     source_wandb_cfg = _normalize_mapping(_normalize_mapping(source_run.run_config).get("wandb"))
     base_name = configured_name or source_wandb_cfg.get("name") or wandb_run.name or "heldout_finetuning"
-    ids_str = "-".join(str(subject_id) for subject_id in heldout_subject_ids)
-    new_name = f"{base_name}_heldout-{ids_str}" if ids_str else str(base_name)
+    suffix = _heldout_subject_run_name_suffix(heldout_subject_ids)
+    new_name = f"{base_name}_{suffix}" if suffix else str(base_name)
     wandb_run.name = new_name
     try:
         wandb_run.config.update({"resolved_heldout_subject_ids": list(heldout_subject_ids)})

--- a/code/post_training_analysis/heldout_finetuning.py
+++ b/code/post_training_analysis/heldout_finetuning.py
@@ -340,7 +340,24 @@ def _resolve_runtime_config(
                 _normalize_mapping(source_model_cfg.get("training")).get("max_grad_norm", 1.0),
             )
         ),
+        # Few-shot adaptation budget: cap each held-out subject's ADAPT (train) sessions
+        # to the first K (deterministic by session order). None/absent = use all adapt
+        # sessions (current behavior). K=0 => no adaptation (zero-shot init eval only).
+        # The EVAL (test) split is never touched, so held-out likelihood stays comparable
+        # across K.
+        "adapt_sessions_per_subject": (
+            None
+            if fine_tune_cfg.get("adapt_sessions_per_subject") is None
+            else int(fine_tune_cfg["adapt_sessions_per_subject"])
+        ),
     }
+    if (
+        resolved["heldout_finetuning"]["adapt_sessions_per_subject"] is not None
+        and resolved["heldout_finetuning"]["adapt_sessions_per_subject"] < 0
+    ):
+        raise ValueError(
+            "heldout_finetuning.adapt_sessions_per_subject must be >= 0 or null."
+        )
     return resolved
 
 
@@ -565,6 +582,110 @@ def _maybe_prepend_session_indices(
     )
 
 
+def _cap_adapt_sessions_per_subject(
+    *,
+    dataset_bundle: DatasetBundle,
+    adapt_sessions_per_subject: int,
+) -> DatasetBundle:
+    """Cap each held-out subject's ADAPT (train) sessions to the first K columns.
+
+    The merged train dataset stacks each subject's adapt sessions along axis 1 in the
+    same order as ``metadata["train_session_ids"]`` (both built in one pass over the
+    per-subject split in ``mice._build_multisubject_bundle``), so column ``j`` of the
+    train set is ``train_session_ids[j]`` whose owning subject is recovered from
+    ``metadata["session_context"]`` (same mapping used by the per-subject eval
+    decomposition). Keeping the first K columns per subject is deterministic by session
+    order. ``dataset_eval`` and ``dataset_full`` are left UNCHANGED so held-out
+    likelihood stays comparable across K. K=0 yields an empty train set (no adaptation).
+    """
+    K = int(adapt_sessions_per_subject)
+    metadata = dict(dataset_bundle.metadata)
+    train_session_ids = [str(s) for s in (metadata.get("train_session_ids") or [])]
+
+    train_set = dataset_bundle.train_set
+    n_columns = int(np.asarray(train_set.get_all()["xs"]).shape[1])
+    if len(train_session_ids) != n_columns:
+        raise ValueError(
+            "adapt-session capping: train session/column mismatch: "
+            f"len(train_session_ids)={len(train_session_ids)} but train array has "
+            f"{n_columns} columns."
+        )
+
+    session_context = _normalize_mapping(metadata.get("session_context"))
+    subject_id_by_session: dict[str, str] = {}
+    for row in session_context.get("per_subject", []):
+        subject_id = str(row.get("subject_id"))
+        for session_id in row.get("ordered_session_ids") or []:
+            subject_id_by_session[str(session_id)] = subject_id
+
+    kept_columns: list[int] = []
+    kept_session_ids: list[str] = []
+    seen_per_subject: dict[str, int] = {}
+    capped_per_subject: dict[str, int] = {}
+    for column_index, session_id in enumerate(train_session_ids):
+        subject_id = subject_id_by_session.get(session_id, "unknown")
+        seen = seen_per_subject.get(subject_id, 0)
+        if seen < K:
+            kept_columns.append(column_index)
+            kept_session_ids.append(session_id)
+            capped_per_subject[subject_id] = capped_per_subject.get(subject_id, 0) + 1
+        seen_per_subject[subject_id] = seen + 1
+
+    logger.info(
+        "Few-shot adaptation budget adapt_sessions_per_subject=%d: capped adapt sessions "
+        "per held-out subject to %s (was %s); total adapt columns %d -> %d",
+        K,
+        capped_per_subject,
+        seen_per_subject,
+        n_columns,
+        len(kept_columns),
+    )
+
+    metadata["adapt_sessions_per_subject"] = K
+    metadata["adapt_sessions_per_subject_counts"] = capped_per_subject
+
+    if not kept_columns:
+        # K=0 (zero-shot): no adapt columns. The DatasetRNN constructor rejects empty
+        # arrays, so we leave the train_set untouched here; the caller forces 0 gradient
+        # steps off ``metadata["adapt_sessions_per_subject"] == 0`` so the embedding stays
+        # at its init and only the step-0 eval + per_subject logging run. The diagnostic
+        # train metrics at step 0 then reflect the un-adapted model on the full train
+        # split, which is harmless (eval is the comparable metric).
+        return DatasetBundle(
+            raw=dataset_bundle.raw,
+            train_set=dataset_bundle.train_set,
+            eval_set=dataset_bundle.eval_set,
+            metadata=metadata,
+            extras=dataset_bundle.extras,
+        )
+
+    _all = train_set.get_all()
+    xs = np.asarray(_all["xs"])
+    ys = np.asarray(_all["ys"])
+    kept = np.asarray(kept_columns, dtype=int)
+    capped_xs = xs[:, kept, :]
+    capped_ys = ys[:, kept, :]
+    dataset_class = train_set.__class__
+    capped_train = dataset_class(
+        capped_xs,
+        capped_ys,
+        y_type=getattr(train_set, "y_type", "categorical"),
+        n_classes=getattr(train_set, "n_classes", None),
+        x_names=list(getattr(train_set, "x_names", [])),
+        y_names=list(getattr(train_set, "y_names", [])),
+        batch_size=getattr(train_set, "batch_size", None),
+        batch_mode=getattr(train_set, "batch_mode", "random"),
+    )
+    metadata["train_session_ids"] = kept_session_ids
+    return DatasetBundle(
+        raw=dataset_bundle.raw,
+        train_set=capped_train,
+        eval_set=dataset_bundle.eval_set,
+        metadata=metadata,
+        extras=dataset_bundle.extras,
+    )
+
+
 def _build_global_heldout_bundle(
     *,
     source_run: Any,
@@ -687,6 +808,12 @@ def _build_global_heldout_bundle(
         dataset_bundle=global_bundle,
         architecture=architecture,
     )
+    adapt_sessions_per_subject = fine_tune_cfg.get("adapt_sessions_per_subject")
+    if adapt_sessions_per_subject is not None:
+        global_bundle = _cap_adapt_sessions_per_subject(
+            dataset_bundle=global_bundle,
+            adapt_sessions_per_subject=int(adapt_sessions_per_subject),
+        )
     logger.info(
         "Held-out fine-tuning dataset shapes after session packing: full input %s, train %s, "
         "eval %s, x_names=%s",
@@ -1450,6 +1577,14 @@ def run_heldout_subject_finetuning_from_config(
             resolved_config["heldout_finetuning"]["checkpoint_every_n_steps"]
         )
         total_steps = int(resolved_config["heldout_finetuning"]["n_steps"])
+        # Zero-shot (K=0): no adapt sessions, so skip all gradient steps and run only the
+        # step-0 init eval + per_subject logging (embedding stays at its init).
+        if int(bundle.metadata.get("adapt_sessions_per_subject", -1)) == 0:
+            logger.info(
+                "No adapt sessions (adapt_sessions_per_subject=0); skipping gradient "
+                "steps and running zero-shot init eval only."
+            )
+            total_steps = 0
         evaluation_steps = [0]
         if checkpoint_every_n_steps <= 0:
             if total_steps > 0:

--- a/code/post_training_analysis/heldout_finetuning.py
+++ b/code/post_training_analysis/heldout_finetuning.py
@@ -869,6 +869,162 @@ def _log_checkpoint_plot_paths_to_wandb(
         wandb_run.log(payload, step=int(step))
 
 
+def _compute_per_subject_eval_likelihood(
+    *,
+    ys_eval: np.ndarray,
+    yhat_eval: np.ndarray,
+    eval_likelihood: float,
+    metadata: Mapping[str, Any],
+    rtol: float = 1e-4,
+) -> dict[str, Any] | None:
+    """Decompose the aggregate eval normalized likelihood per held-out subject/session.
+
+    The merged eval dataset stacks each held-out subject's eval sessions along axis 1
+    (episodes) in the same order they appear in ``metadata["eval_session_ids"]`` (both
+    are built in a single pass over the same per-subject split in
+    ``mice._build_multisubject_bundle``). Column ``j`` of ``ys_eval``/``yhat_eval`` is
+    therefore eval session ``eval_session_ids[j]``, whose owning subject is recovered from
+    ``metadata["session_context"]``.
+
+    Normalized likelihood is ``exp(-total_nll / n_unmasked)`` (see
+    ``rnn_utils.normalized_likelihood``), so per-session and per-subject values are the
+    same quantity recomputed over the relevant columns; the per-subject aggregate is the
+    trial-count-weighted combination of its sessions' log-likelihoods (i.e. recomputed
+    over the subject's eval trials), not a plain mean of per-session values.
+
+    Returns the JSON-ready wrapper dict, or ``None`` if the decomposition fails.
+    """
+    try:
+        ys_eval = np.asarray(ys_eval)
+        yhat_eval = np.asarray(yhat_eval)
+        eval_session_ids = [str(s) for s in (metadata.get("eval_session_ids") or [])]
+        n_columns = int(ys_eval.shape[1])
+        if len(eval_session_ids) != n_columns:
+            raise ValueError(
+                "eval session/column mismatch: "
+                f"len(eval_session_ids)={len(eval_session_ids)} but eval array has "
+                f"{n_columns} columns."
+            )
+
+        # ses_idx -> subject_id from the session context (the same unique ses_idx form
+        # used for the merged dataset columns).
+        session_context = _normalize_mapping(metadata.get("session_context"))
+        subject_id_by_session: dict[str, str] = {}
+        for row in session_context.get("per_subject", []):
+            subject_id = str(row.get("subject_id"))
+            for session_id in row.get("ordered_session_ids") or []:
+                subject_id_by_session[str(session_id)] = subject_id
+
+        # Per-column total nll and unmasked-sample count.
+        per_subject_records: list[dict[str, Any]] = []
+        subject_order: list[str] = []
+        subject_nll: dict[str, float] = {}
+        subject_n: dict[str, int] = {}
+        total_nll = 0.0
+        total_n = 0
+        for column_index, session_id in enumerate(eval_session_ids):
+            subject_id = subject_id_by_session.get(session_id, "unknown")
+            column_ys = ys_eval[:, column_index : column_index + 1, :]
+            column_yhat = yhat_eval[:, column_index : column_index + 1, :]
+            nll, n_unmasked = rnn_utils.categorical_neg_log_likelihood(
+                column_ys, column_yhat
+            )
+            nll = float(nll)
+            n_unmasked = int(n_unmasked)
+            session_likelihood = (
+                float(np.exp(-nll / n_unmasked)) if n_unmasked > 0 else float("nan")
+            )
+            per_subject_records.append(
+                {
+                    "heldout_subject_id": subject_id,
+                    "ses_idx": session_id,
+                    "split": "eval",
+                    "n_trials": n_unmasked,
+                    "likelihood": session_likelihood,
+                }
+            )
+            if subject_id not in subject_nll:
+                subject_order.append(subject_id)
+                subject_nll[subject_id] = 0.0
+                subject_n[subject_id] = 0
+            subject_nll[subject_id] += nll
+            subject_n[subject_id] += n_unmasked
+            total_nll += nll
+            total_n += n_unmasked
+
+        for subject_id in subject_order:
+            n_subject = subject_n[subject_id]
+            subject_likelihood = (
+                float(np.exp(-subject_nll[subject_id] / n_subject))
+                if n_subject > 0
+                else float("nan")
+            )
+            per_subject_records.append(
+                {
+                    "heldout_subject_id": subject_id,
+                    "ses_idx": None,
+                    "split": "eval",
+                    "n_trials": int(n_subject),
+                    "likelihood": subject_likelihood,
+                }
+            )
+
+        # Correctness guard: the trial-count-weighted aggregate over ALL eval trials must
+        # reproduce the existing aggregate eval_likelihood scalar.
+        aggregate_likelihood = (
+            float(np.exp(-total_nll / total_n)) if total_n > 0 else float("nan")
+        )
+        if total_n > 0 and not np.isclose(
+            aggregate_likelihood, float(eval_likelihood), rtol=0.0, atol=rtol
+        ):
+            logger.warning(
+                "Per-subject eval-likelihood decomposition does not reproduce the "
+                "aggregate eval_likelihood (decomposed=%.6f vs aggregate=%.6f, atol=%g); "
+                "the per-subject breakdown may not be faithful.",
+                aggregate_likelihood,
+                float(eval_likelihood),
+                rtol,
+            )
+
+        return {
+            "eval_likelihood_aggregate": float(eval_likelihood),
+            "n_heldout_subjects": int(len(subject_order)),
+            "records": per_subject_records,
+        }
+    except Exception as exc:  # never crash the run or the aggregate metric
+        logger.warning("Per-subject eval-likelihood decomposition failed: %s", exc)
+        return None
+
+
+def _log_per_subject_likelihood_to_wandb(
+    *,
+    wandb_run: Any,
+    per_subject_likelihood: Mapping[str, Any],
+) -> None:
+    """Log a compact per-subject eval-likelihood table to the held-out W&B run."""
+    try:
+        import wandb
+    except ModuleNotFoundError:
+        logger.warning("wandb is unavailable; skipping per-subject likelihood table.")
+        return
+    try:
+        subject_rows = [
+            row
+            for row in per_subject_likelihood.get("records", [])
+            if row.get("ses_idx") is None
+        ]
+        table = wandb.Table(columns=["heldout_subject_id", "n_trials", "eval_likelihood"])
+        for row in subject_rows:
+            table.add_data(
+                str(row.get("heldout_subject_id")),
+                int(row.get("n_trials", 0)),
+                float(row.get("likelihood")),
+            )
+        wandb_run.log({"heldout/per_subject_likelihood": table})
+    except Exception as exc:
+        logger.warning("Failed to log per-subject likelihood table to W&B: %s", exc)
+
+
 def _evaluate_checkpoint(
     *,
     model_type: str,
@@ -980,6 +1136,12 @@ def _evaluate_checkpoint(
         "train_likelihood": float(train_likelihood),
         "eval_likelihood": float(eval_likelihood),
     }
+    record["per_subject_likelihood"] = _compute_per_subject_eval_likelihood(
+        ys_eval=ys_eval,
+        yhat_eval=np.asarray(yhat_eval_eval)[:, :, :eval_n_action_logits],
+        eval_likelihood=eval_likelihood,
+        metadata=bundle.metadata,
+    )
     record["plot_paths"] = _save_state_space_figures(
         trainer=trainer,
         params=params,
@@ -1376,6 +1538,25 @@ def run_heldout_subject_finetuning_from_config(
 
         _save_params(outputs_dir / "params.json", params)
         _save_json(outputs_dir / "checkpoint_metrics.json", checkpoint_records)
+
+        # Per-held-out-subject / per-session eval likelihood decomposition (from the
+        # final checkpoint). Tidy artifact + compact W&B table for downstream paired
+        # statistics across data-scaling conditions. Add-only; never gates the run.
+        final_per_subject_likelihood = (
+            checkpoint_records[-1].get("per_subject_likelihood")
+            if checkpoint_records
+            else None
+        )
+        if final_per_subject_likelihood is not None:
+            _save_json(
+                outputs_dir / "per_subject_likelihood.json",
+                final_per_subject_likelihood,
+            )
+            if wandb_run is not None:
+                _log_per_subject_likelihood_to_wandb(
+                    wandb_run=wandb_run,
+                    per_subject_likelihood=final_per_subject_likelihood,
+                )
         _save_json(
             checkpoints_root / "index.json",
             {

--- a/code/tests/test_gru_trainer.py
+++ b/code/tests/test_gru_trainer.py
@@ -286,6 +286,44 @@ class TestGruTrainer(unittest.TestCase):
             self.assertLessEqual(checkpoint["train_likelihood"], 1.0)
         self.assertTrue((self.output_dir / "checkpoints" / "index.json").exists())
 
+    def test_early_stop_final_metadata_uses_completed_step(self):
+        trainer = GruTrainer(
+            architecture={"hidden_size": 8, "num_layers": 1},
+            training={
+                "lr": 1e-3,
+                "n_steps": 4,
+                "loss": "categorical",
+                "loss_param": 1,
+                "max_grad_norm": 1.0,
+                "checkpoint_every_n_steps": 2,
+                "checkpoint_plot_split_examples_every_n": 0,
+                "checkpoint_save_output_df_every_n": 0,
+                "checkpoint_log_eval_to_wandb": False,
+                "checkpoint_log_split_examples_to_wandb": False,
+                "checkpoint_run_heldout_eval": False,
+                "early_stopping": {
+                    "enabled": True,
+                    "metric": "eval_likelihood",
+                    "patience": 0,
+                    "start_after_step": 0,
+                },
+            },
+            output_dir=str(self.output_dir),
+            seed=42,
+        )
+
+        output = trainer.fit(self.bundle)
+        index = json.loads((self.output_dir / "checkpoints" / "index.json").read_text())
+
+        self.assertEqual(output["training_steps_completed"], 2)
+        self.assertEqual(output["training_steps_requested"], 4)
+        self.assertEqual(index["n_steps"], 2)
+        self.assertEqual(index["completed_steps"], 2)
+        self.assertEqual(index["requested_n_steps"], 4)
+        self.assertTrue(index["early_stopped"])
+        self.assertTrue((self.output_dir / "checkpoints" / "step_2").exists())
+        self.assertFalse((self.output_dir / "checkpoints" / "step_4").exists())
+
     def test_multisubject_training_exports_subject_artifacts(self):
         trainer = GruTrainer(
             architecture={

--- a/code/tests/test_heldout_finetuning.py
+++ b/code/tests/test_heldout_finetuning.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from dataclasses import asdict
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 try:
@@ -24,6 +25,8 @@ try:
     from models.gru_network import make_gru_network
     from models.session_conditioning import resolve_session_conditioning_from_architecture
     from post_training_analysis.heldout_finetuning import (
+        _heldout_subject_run_name_suffix,
+        _maybe_start_wandb_run,
         run_heldout_subject_finetuning_from_config,
     )
     from utils.multisubject import (
@@ -570,6 +573,41 @@ class TestHeldoutSubjectFinetuning(unittest.TestCase):
             captured_selector["test_subject_ids"],
             list(self.heldout_subject_ids),
         )
+
+    def test_heldout_subject_run_name_suffix_is_compact_and_stable(self):
+        suffix = _heldout_subject_run_name_suffix(["s1", "s2", "s3"])
+
+        self.assertRegex(suffix, r"^heldout-n3-[0-9a-f]{8}$")
+        self.assertEqual(suffix, _heldout_subject_run_name_suffix(["s1", "s2", "s3"]))
+        self.assertNotIn("s1-s2-s3", suffix)
+        self.assertEqual(_heldout_subject_run_name_suffix([]), "")
+
+    def test_standalone_wandb_init_uses_retry_fallback_helper(self):
+        fake_run = _FakeWandbRun()
+        resolved_config = {"wandb": {"project": "proj"}, "meta": {"kind": "test"}}
+        source_run = SimpleNamespace(
+            model_type="gru",
+            run_config={"wandb": {"name": "source-run"}},
+        )
+
+        with mock.patch(
+            "utils.run_helpers._init_wandb_with_fallback",
+            return_value=fake_run,
+        ) as init_with_fallback:
+            run = _maybe_start_wandb_run(
+                resolved_config=resolved_config,
+                run_dir=self.output_root,
+                source_run=source_run,
+            )
+
+        self.assertIs(run, fake_run)
+        init_with_fallback.assert_called_once()
+        init_kwargs = init_with_fallback.call_args.args[0]
+        self.assertEqual(init_kwargs["project"], "proj")
+        self.assertEqual(init_kwargs["name"], "source-run")
+        self.assertEqual(init_kwargs["config"], resolved_config)
+        self.assertIn("heldout_subject_finetuning", init_kwargs["tags"])
+        self.assertIn("gru", init_kwargs["tags"])
 
     # --- Auto held-out fine-tuning: injected W&B run + namespacing ------------
 

--- a/code/tests/test_post_training_analysis.py
+++ b/code/tests/test_post_training_analysis.py
@@ -10,6 +10,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import numpy as np
+
 from post_training_analysis import generative_analysis
 from post_training_analysis.generative_analysis import (
     _parse_simple_yaml,
@@ -343,21 +345,17 @@ seed: 7
                 self.calls.append((subject_id, encoded))
                 return encoded
 
-            def step(self, inputs, prev_state):
-                self.calls[-1] = (self.calls[-1][0], list(inputs))
-                return [50.0, -50.0], prev_state
+            def initial_state_batch(self, batch_size):
+                return {"hidden": [0] * int(batch_size)}
+
+            def step_batch(self, inputs_2d, prev_state):
+                if not hasattr(self, "batched_inputs"):
+                    self.batched_inputs = []
+                arr = np.asarray(inputs_2d, dtype=float)
+                self.batched_inputs.append(arr.tolist())
+                return np.array([[50.0, -50.0]] * arr.shape[0]), prev_state
 
         fake_runner = _FakeRunner()
-
-        class _FakeRng:
-            def choice(self, n_actions, p):
-                return 0
-
-        class _FakeNumpy:
-            class random:
-                @staticmethod
-                def default_rng(seed):
-                    return _FakeRng()
 
         class _FakePandas:
             class DataFrame:
@@ -381,7 +379,7 @@ seed: 7
             generative_analysis,
             "_import_dependency",
             side_effect=lambda module_name: (
-                _FakeNumpy
+                np
                 if module_name == "numpy"
                 else _FakePandas
                 if module_name == "pandas"
@@ -395,13 +393,17 @@ seed: 7
             )
 
         self.assertEqual(len(simulated), 2)
+        # encode_inputs is called once per lane to build the constant prefix
+        # (subject index), in lane order.
+        self.assertEqual([subject for subject, _ in fake_runner.calls], ["m1", "m2"])
+        # The model step is batched across lanes, one call per trial. Each row
+        # carries [subject_index, prev_choice, prev_reward]; row b == the old
+        # per-session step for lane b.
         self.assertEqual(
-            fake_runner.calls,
+            fake_runner.batched_inputs,
             [
-                ("m1", [0.0, -1.0, -1.0]),
-                ("m1", [0.0, 0.0, 1.0]),
-                ("m2", [1.0, -1.0, -1.0]),
-                ("m2", [1.0, 0.0, 1.0]),
+                [[0.0, -1.0, -1.0], [1.0, -1.0, -1.0]],
+                [[0.0, 0.0, 1.0], [1.0, 0.0, 1.0]],
             ],
         )
 
@@ -491,21 +493,17 @@ seed: 7
                 self.calls.append((subject_id, encoded))
                 return encoded
 
-            def step(self, inputs, prev_state):
-                self.calls[-1] = (self.calls[-1][0], list(inputs))
-                return [50.0, -50.0], prev_state
+            def initial_state_batch(self, batch_size):
+                return {"hidden": [0] * int(batch_size)}
+
+            def step_batch(self, inputs_2d, prev_state):
+                if not hasattr(self, "batched_inputs"):
+                    self.batched_inputs = []
+                arr = np.asarray(inputs_2d, dtype=float)
+                self.batched_inputs.append(arr.tolist())
+                return np.array([[50.0, -50.0]] * arr.shape[0]), prev_state
 
         fake_runner = _FakeRunner()
-
-        class _FakeRng:
-            def choice(self, n_actions, p):
-                return 0
-
-        class _FakeNumpy:
-            class random:
-                @staticmethod
-                def default_rng(seed):
-                    return _FakeRng()
 
         class _FakePandas:
             class DataFrame:
@@ -529,7 +527,7 @@ seed: 7
             generative_analysis,
             "_import_dependency",
             side_effect=lambda module_name: (
-                _FakeNumpy
+                np
                 if module_name == "numpy"
                 else _FakePandas
                 if module_name == "pandas"
@@ -543,15 +541,74 @@ seed: 7
             )
 
         self.assertEqual(len(simulated), 2)
+        self.assertEqual([subject for subject, _ in fake_runner.calls], ["m1", "m2"])
+        # Batched step inputs carry [subject_index, session_index, prev_choice,
+        # prev_reward] for each lane, one batched call per trial.
         self.assertEqual(
-            fake_runner.calls,
+            fake_runner.batched_inputs,
             [
-                ("m1", [0.0, 1.0, -1.0, -1.0]),
-                ("m1", [0.0, 1.0, 0.0, 1.0]),
-                ("m2", [1.0, 1.0, -1.0, -1.0]),
-                ("m2", [1.0, 1.0, 0.0, 1.0]),
+                [[0.0, 1.0, -1.0, -1.0], [1.0, 1.0, -1.0, -1.0]],
+                [[0.0, 1.0, 0.0, 1.0], [1.0, 1.0, 0.0, 1.0]],
             ],
         )
+
+    def test_run_batched_rollout_matches_per_lane_and_respects_lengths(self):
+        # The only non-trivial part of batching is variable session lengths:
+        # a batched rollout must (a) produce, for each lane, exactly what a
+        # solo (batch-1) rollout of that lane would, and (b) not over-run a
+        # short lane just because a longer lane shares the batch.
+        class _Runner:
+            n_actions = 2
+
+            def encode_inputs(self, subject_id, session_id, inputs, *, source_session_id=None):
+                return [float(subject_id), *list(inputs)]
+
+            def initial_state_batch(self, batch_size):
+                return np.zeros((int(batch_size), 1), dtype=float)
+
+            def step_batch(self, inputs_2d, prev_state):
+                arr = np.asarray(inputs_2d, dtype=float)
+                # Row-independent recurrence: state[b] depends only on input[b].
+                state = np.asarray(prev_state, dtype=float) + arr[:, :1]
+                logits = np.stack([state[:, 0], -state[:, 0]], axis=1)
+                return logits, state
+
+        lanes = [
+            {"subject_id": 0, "model_ses_idx": "a", "source_ses_idx": "a",
+             "curriculum_name": "Uncoupled Baiting", "n_trials": 3, "seed": 7},
+            {"subject_id": 1, "model_ses_idx": "b", "source_ses_idx": "b",
+             "curriculum_name": "Uncoupled Baiting", "n_trials": 1, "seed": 9},
+        ]
+
+        class _Task:
+            def __init__(self, seed):
+                self.rng = np.random.default_rng(seed)
+
+            def reset(self):
+                pass
+
+        with mock.patch.object(
+            generative_analysis,
+            "_build_curriculum_matched_task",
+            side_effect=lambda **kwargs: _Task(kwargs["seed"]),
+        ), mock.patch.object(
+            generative_analysis,
+            "_step_task_reward",
+            side_effect=lambda task, action: float(task.rng.integers(0, 2)),
+        ):
+            runner = _Runner()
+            ch_both, rw_both = generative_analysis._run_batched_rollout(runner, lanes, n_actions=2)
+            ch0, rw0 = generative_analysis._run_batched_rollout(runner, [lanes[0]], n_actions=2)
+            ch1, rw1 = generative_analysis._run_batched_rollout(runner, [lanes[1]], n_actions=2)
+
+        # Lengths respected: short lane not over-run despite batch max_trials=3.
+        self.assertEqual(len(ch_both[0]), 3)
+        self.assertEqual(len(ch_both[1]), 1)
+        # Batched == per-lane, bit-for-bit (batch-independence + correct masking).
+        self.assertEqual(ch_both[0], ch0[0])
+        self.assertEqual(rw_both[0], rw0[0])
+        self.assertEqual(ch_both[1], ch1[0])
+        self.assertEqual(rw_both[1], rw1[0])
 
     def test_parse_simple_yaml_handles_saved_hydra_inputs(self):
         parsed = _parse_simple_yaml(

--- a/code/tests/test_post_training_analysis.py
+++ b/code/tests/test_post_training_analysis.py
@@ -655,6 +655,26 @@ seed: 7
                     curriculum_name="RandomWalkFooCurriculum", n_trials=5, seed=1
                 )
 
+    def test_partition_filter_matches_animal_on_source_namespace(self):
+        # Multisubject animal rows are aligned to the merged namespace (ses_idx)
+        # but carry source_ses_idx in the manifest's source namespace. The
+        # train/eval partition filter must match on source_ses_idx, else every
+        # animal session is dropped (the train/eval "only simulated bar" bug).
+        rows = [
+            {"ses_idx": "632105__632105_s1", "source_ses_idx": "632105_s1", "subject_id": "632105"},
+            {"ses_idx": "632105__632105_s2", "source_ses_idx": "632105_s2", "subject_id": "632105"},
+        ]
+        allowed = ["632105_s1"]  # source-namespace manifest id (as in train/eval)
+        kept = generative_analysis._filter_session_rows_by_session_ids(
+            rows, allowed_session_ids=allowed, prefer_source_session_ids=True
+        )
+        self.assertEqual([r["source_ses_idx"] for r in kept], ["632105_s1"])
+        # The pre-fix behaviour matched on the merged ses_idx and dropped all:
+        dropped = generative_analysis._filter_session_rows_by_session_ids(
+            rows, allowed_session_ids=allowed, prefer_source_session_ids=False
+        )
+        self.assertEqual(len(dropped), 0)
+
     def test_parse_simple_yaml_handles_saved_hydra_inputs(self):
         parsed = _parse_simple_yaml(
             """

--- a/code/tests/test_post_training_analysis.py
+++ b/code/tests/test_post_training_analysis.py
@@ -610,6 +610,51 @@ seed: 7
         self.assertEqual(ch_both[1], ch1[0])
         self.assertEqual(rw_both[1], rw1[0])
 
+    def test_build_curriculum_matched_task_maps_family_and_version_variants(self):
+        # Family-level mapping (coupled/uncoupled + baiting), robust to curriculum
+        # *version* suffixes like "2p3". NOTE: deliberately family-only (default
+        # task params, stage ignored) — see the TODO in the function.
+        calls = []
+
+        class _FakeTaskMod:
+            class UncoupledBlockTask:
+                def __init__(self, **kwargs):
+                    calls.append(("Uncoupled", kwargs))
+
+            class CoupledBlockTask:
+                def __init__(self, **kwargs):
+                    calls.append(("Coupled", kwargs))
+
+        real_import = generative_analysis.importlib.import_module
+        with mock.patch.object(
+            generative_analysis.importlib,
+            "import_module",
+            side_effect=lambda name, *a, **k: (
+                _FakeTaskMod if "dynamic_foraging.task" in name else real_import(name, *a, **k)
+            ),
+        ):
+            cases = {
+                "Uncoupled Baiting": ("Uncoupled", True),
+                "Uncoupled Without Baiting": ("Uncoupled", False),
+                "Coupled Baiting": ("Coupled", True),
+                "None": ("Uncoupled", True),
+                None: ("Uncoupled", True),
+                # the high-D failure that motivated the fix:
+                "UnCoupledBaiting2p3Curriculum": ("Uncoupled", True),
+            }
+            for name, (family, baiting) in cases.items():
+                calls.clear()
+                generative_analysis._build_curriculum_matched_task(
+                    curriculum_name=name, n_trials=5, seed=1
+                )
+                self.assertEqual(calls[-1][0], family, msg=f"{name!r} family")
+                self.assertEqual(calls[-1][1].get("reward_baiting"), baiting, msg=f"{name!r} baiting")
+            # A non-block-task family still raises (don't silently mis-map it).
+            with self.assertRaises(ValueError):
+                generative_analysis._build_curriculum_matched_task(
+                    curriculum_name="RandomWalkFooCurriculum", n_trials=5, seed=1
+                )
+
     def test_parse_simple_yaml_handles_saved_hydra_inputs(self):
         parsed = _parse_simple_yaml(
             """

--- a/code/utils/run_helpers.py
+++ b/code/utils/run_helpers.py
@@ -299,13 +299,16 @@ def start_wandb_run(
     #  - platform-native cross-ref ids (alongside CO_COMPUTATION_ID): Beaker exp/job +
     #    code SHAs — for jumping to the exact run on each platform.
     #  - `meta`: our portable, human-readable system (study / variant / launch_id /
-    #    label / config_hash), set by launch_beaker_resumable.py via DISRNN_META_* env —
-    #    consistent across CO / Beaker / AI1 HPC. Merge-safe with any config `meta`.
+    #    label / note / config_hash), set by launch_beaker_resumable.py via DISRNN_META_*
+    #    env — consistent across CO / Beaker / AI1 HPC. Merge-safe with any config `meta`.
+    #    `note` is a free-text "why this run exists + what we want to learn" so humans and
+    #    agents can read intent straight from the run record.
     meta_env = {
         "study": os.environ.get("DISRNN_META_STUDY"),
         "variant": os.environ.get("DISRNN_META_VARIANT"),
         "launch_id": os.environ.get("DISRNN_META_LAUNCH_ID"),
         "label": os.environ.get("DISRNN_META_LABEL"),
+        "note": os.environ.get("DISRNN_META_NOTE"),
         "config_hash": os.environ.get("DISRNN_META_CONFIG_HASH"),
     }
     meta = {**(run.config.get("meta") or {}), **{k: v for k, v in meta_env.items() if v}}


### PR DESCRIPTION
## Summary
- add training metadata/provenance support used by the data-scaling study
- add held-out, few-shot, and per-session likelihood support
- speed up and harden generative analysis for the study reruns

## Notes
- Opened from study/data-scaling-law into ai_hub_pck_integration.
- Please merge with a merge commit, not squash, to preserve per-commit provenance.