### PR TITLE
Log disRNN bottleneck sparsity at loss pace + step-0 baseline

### DIFF
--- a/code/model_trainers/disrnn_trainer.py
+++ b/code/model_trainers/disrnn_trainer.py
@@ -1054,6 +1054,7 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
             optimizer: Any,
             wandb_step_offset: int = 0,
             total_step_offset: int = 0,
+            log_bottleneck_sparsity: bool = False,
         ):
             return train_network_with_session_regularization(
                 make_current_network,
@@ -1078,6 +1079,11 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
                 report_progress_by="wandb",
                 wandb_run=wandb_run,
                 wandb_step_offset=wandb_step_offset,
+                bottleneck_sparsity_fn=(
+                    compute_bottleneck_sparsity_metrics
+                    if log_bottleneck_sparsity
+                    else None
+                ),
             )
 
         def _compute_distillation_metrics(
@@ -1168,6 +1174,19 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
                 optimizer=optax.adam(args.learning_rate),
                 total_step_offset=0,
             )
+            # Step-0 bottleneck-sparsity baseline. The library initializes every
+            # bottleneck sigma from RandomUniform(0, 0.05) -> all bottlenecks OPEN
+            # (frac_open == 1.0) at init. Logging here (at wandb step 0, before
+            # warmup/penalty pressure) captures that baseline so the open->closed
+            # trajectory driven by update_net_latent_penalty_multiplier is visible
+            # rather than jumping straight to the first periodic checkpoint.
+            if wandb_run is not None:
+                init_sparsity = compute_bottleneck_sparsity_metrics(params)
+                if init_sparsity:
+                    wandb_run.log(
+                        {**init_sparsity, "checkpoint/step": 0},
+                        step=0,
+                    )
             initial_evaluations: dict[str, Any] = {}
             if args.initialization_eval_before_warmup:
                 initial_evaluations["before_warmup"] = self._evaluate_initialization_snapshot(
@@ -1312,6 +1331,7 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
                     optimizer=optax.adam(args.learning_rate),
                     wandb_step_offset=args.n_warmup_steps,
                     total_step_offset=int(args.n_warmup_steps),
+                    log_bottleneck_sparsity=True,
                 )
             else:
                 params, opt_state, losses = train_network_with_distillation(
@@ -1380,6 +1400,7 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
                             optimizer=optimizer,
                             wandb_step_offset=args.n_warmup_steps + steps_completed,
                             total_step_offset=int(args.n_warmup_steps + steps_completed),
+                            log_bottleneck_sparsity=True,
                         )
                     )
                 else:
@@ -1754,20 +1775,11 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
                         step=args.n_warmup_steps + int(steps_completed),
                     )
 
-                # Real-time bottleneck-sparsity scalars (total_sigma, per-family
-                # open/closed counts + the isolated update_net_latent channel that
-                # update_net_latent_penalty_multiplier drives). Cheap: reads params,
-                # no forward pass. Returns {} and no-ops on any param-layout issue.
-                if wandb_run is not None and args.checkpoint_log_eval_to_wandb:
-                    sparsity_metrics = compute_bottleneck_sparsity_metrics(params)
-                    if sparsity_metrics:
-                        wandb_run.log(
-                            {
-                                **sparsity_metrics,
-                                "checkpoint/step": int(steps_completed),
-                            },
-                            step=args.n_warmup_steps + int(steps_completed),
-                        )
+                # NOTE: bottleneck-sparsity scalars are logged at loss pace inside
+                # the training loop (train_network_with_session_regularization,
+                # log_losses_every), plus a step-0 baseline before warmup, so no
+                # per-checkpoint sparsity log is needed here. The end-of-run
+                # final/bottlenecks/* summary write is still below.
                 if (
                     wandb_run is not None
                     and eval_distillation_loss_ckpt is not None

--- a/code/model_trainers/disrnn_trainer.py
+++ b/code/model_trainers/disrnn_trainer.py
@@ -62,7 +62,10 @@ from utils.multisubject import (
     session_regularization_index_arrays_from_session_context,
     subject_embeddings_to_dataframe,
 )
-from utils.run_helpers import resolve_disrnn_penalties
+from utils.run_helpers import (
+    compute_bottleneck_sparsity_metrics,
+    resolve_disrnn_penalties,
+)
 from utils.session_regularized_training import (
     build_zero_mean_session_delta_regularization_apply,
     train_network_with_session_regularization,
@@ -1750,6 +1753,21 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
                         },
                         step=args.n_warmup_steps + int(steps_completed),
                     )
+
+                # Real-time bottleneck-sparsity scalars (total_sigma, per-family
+                # open/closed counts + the isolated update_net_latent channel that
+                # update_net_latent_penalty_multiplier drives). Cheap: reads params,
+                # no forward pass. Returns {} and no-ops on any param-layout issue.
+                if wandb_run is not None and args.checkpoint_log_eval_to_wandb:
+                    sparsity_metrics = compute_bottleneck_sparsity_metrics(params)
+                    if sparsity_metrics:
+                        wandb_run.log(
+                            {
+                                **sparsity_metrics,
+                                "checkpoint/step": int(steps_completed),
+                            },
+                            step=args.n_warmup_steps + int(steps_completed),
+                        )
                 if (
                     wandb_run is not None
                     and eval_distillation_loss_ckpt is not None
@@ -2257,6 +2275,12 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
 
             wandb_run.summary["elapsed_seconds"] = float(training_time)
             wandb_run.summary["warmup_seconds"] = float(warmup_duration)
+
+            # Final bottleneck-sparsity scalars -> wandb.summary so they are
+            # queryable per-run (same route as `likelihood`) for post-hoc analysis.
+            final_sparsity = compute_bottleneck_sparsity_metrics(params)
+            for _k, _v in final_sparsity.items():
+                wandb_run.summary[f"final/{_k}"] = _v
 
             # Upload the whole /results/output folder as an artifact
             # Here I'm using the random id as the name, meaning each run will has its own artifact.

--- a/code/utils/run_helpers.py
+++ b/code/utils/run_helpers.py
@@ -343,3 +343,80 @@ def copy_run_to_wandb(run_dir: Path, wandb_dir: Path) -> None:
             shutil.copytree(item, destination, dirs_exist_ok=True)
         else:
             shutil.copy2(item, destination)
+
+
+def compute_bottleneck_sparsity_metrics(
+    params: Any,
+    open_thresh: float = 0.1,
+    closed_thresh: float = 0.9,
+) -> dict[str, float]:
+    """Compute real-time bottleneck-sparsity scalars for a Multisubject DisRNN.
+
+    Wraps the upstream ``multisubject_disrnn.get_auxiliary_metrics`` (which returns
+    ``total_sigma`` plus per-family open/closed *counts*) and augments it with:
+
+    - an isolated ``update_net_latent`` bottleneck breakout (mean sigma + open/closed
+      counts). This is the channel that ``update_net_latent_penalty_multiplier``
+      directly targets, so it is the primary readout for the beta-scan study; the
+      upstream ``update_bottlenecks_*`` aggregates subj+obs+latent and hides it.
+    - a ``bottlenecks/`` W&B namespace and fraction-open values for each family so a
+      run's interaction sparsity is visible in real time on the W&B dashboard.
+
+    Returns a flat dict of floats/ints keyed under ``bottlenecks/*``. On any failure
+    (unexpected param layout, non-multisubject params) it returns ``{}`` so logging
+    never breaks training.
+    """
+    try:
+        import numpy as np
+        from disentangled_rnns.library import disrnn as _disrnn
+        from disentangled_rnns.library import (
+            multisubject_disrnn as _ms_disrnn,
+        )
+
+        out: dict[str, float] = {}
+
+        # Upstream aggregate metrics (total_sigma + per-family open/closed counts).
+        try:
+            aux = _ms_disrnn.get_auxiliary_metrics(
+                params, open_thresh=open_thresh, closed_thresh=closed_thresh
+            )
+            for k, v in aux.items():
+                out[f"bottlenecks/{k}"] = float(v)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("get_auxiliary_metrics failed: %s", exc)
+
+        # Isolated per-family sigmas, incl. the update_net_latent channel the
+        # multiplier drives. Param module key is 'multisubject_dis_rnn'.
+        module_params = None
+        if isinstance(params, dict):
+            module_params = params.get("multisubject_dis_rnn")
+        if module_params is not None:
+            families = {
+                "latent": "latent_sigma_params",
+                "update_net_subj": "update_net_subj_sigma_params",
+                "update_net_obs": "update_net_obs_sigma_params",
+                "update_net_latent": "update_net_latent_sigma_params",
+                "choice_net_subj": "choice_net_subj_sigma_params",
+                "choice_net_latent": "choice_net_latent_sigma_params",
+            }
+            for fam, key in families.items():
+                if key not in module_params:
+                    continue
+                sig = np.array(
+                    _disrnn.reparameterize_sigma(module_params[key])
+                ).ravel()
+                n = int(sig.size)
+                if n == 0:
+                    continue
+                n_open = int(np.sum(sig < open_thresh))
+                n_closed = int(np.sum(sig > closed_thresh))
+                out[f"bottlenecks/{fam}_mean_sigma"] = float(np.mean(sig))
+                out[f"bottlenecks/{fam}_min_sigma"] = float(np.min(sig))
+                out[f"bottlenecks/{fam}_n_open"] = n_open
+                out[f"bottlenecks/{fam}_n_closed"] = n_closed
+                out[f"bottlenecks/{fam}_frac_open"] = float(n_open) / n
+
+        return out
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("compute_bottleneck_sparsity_metrics failed: %s", exc)
+        return {}

--- a/code/utils/session_regularized_training.py
+++ b/code/utils/session_regularized_training.py
@@ -224,8 +224,19 @@ def train_network_with_session_regularization(
     report_progress_by: ProgressMode = "print",
     wandb_run: Any | None = None,
     wandb_step_offset: int = 0,
+    bottleneck_sparsity_fn: Callable[[Any], Mapping[str, Any]] | None = None,
 ) -> tuple[Any, optax.OptState, dict[str, np.ndarray]]:
-    """Train an RNN with an exact zero-mean session-delta penalty."""
+    """Train an RNN with an exact zero-mean session-delta penalty.
+
+    ``bottleneck_sparsity_fn``: optional ``params -> {metric: value}`` callable
+    (e.g. ``run_helpers.compute_bottleneck_sparsity_metrics``). When set and
+    logging to W&B, its scalars are logged in the SAME payload as the loss, at
+    the ``log_losses_every`` cadence — so bottleneck sparsity is tracked at loss
+    pace, not only at the (rarer, eval-gated) checkpoint boundaries. It reads
+    only param sigmas (no forward pass), so the added cost is one device->host
+    sync of a few tiny arrays per logged step. Left ``None`` for non-disRNN
+    callers, which have no bottlenecks.
+    """
     resolved_loss = str(loss).strip().lower()
     if resolved_loss not in {"categorical", "penalized_categorical"}:
         raise ValueError(
@@ -392,16 +403,21 @@ def train_network_with_session_regularization(
             elif report_progress_by == "log":
                 logger.info(log_str)
             elif report_progress_by == "wandb" and wandb_run is not None:
-                wandb_run.log(
-                    {
-                        "train/loss": float(loss_value),
-                        "valid/loss": float(validation_value),
-                        "train/session_curriculum_lambda": float(
-                            current_session_curriculum_lambda
-                        ),
-                    },
-                    step=wandb_step_offset + step,
-                )
+                payload = {
+                    "train/loss": float(loss_value),
+                    "valid/loss": float(validation_value),
+                    "train/session_curriculum_lambda": float(
+                        current_session_curriculum_lambda
+                    ),
+                }
+                # Bottleneck-sparsity scalars at loss pace (param sigmas only, no
+                # forward pass). Fails closed: on any issue it returns {} and the
+                # loss log proceeds unchanged.
+                if bottleneck_sparsity_fn is not None:
+                    sparsity = bottleneck_sparsity_fn(params)
+                    if sparsity:
+                        payload.update(sparsity)
+                wandb_run.log(payload, step=wandb_step_offset + step)
 
     return params, opt_state, {
         "training_loss": np.asarray(training_loss, dtype=float),


### PR DESCRIPTION
## Real-time bottleneck-sparsity logging for disRNN

Logs disRNN bottleneck-sparsity scalars to W&B **at loss pace** (every `log_losses_every` steps) instead of only at checkpoint boundaries, plus a **step-0 baseline** (all bottlenecks open at init).

**Why:** the metric reads only bottleneck `sigma_params` (`reparameterize_sigma` + threshold counts) — no forward pass, no eval batch — so gating it behind the expensive checkpoint eval was needlessly coarse and could miss the entire open->closed transition that `update_net_latent_penalty_multiplier` drives.

**Changes (3 files, wrapper only — no upstream/library change, no image rebuild):**
- `run_helpers.py`: `compute_bottleneck_sparsity_metrics(params)` — wraps the pinned fork's `multisubject_disrnn.get_auxiliary_metrics` + an isolated `update_net_latent` breakout (the multiplier's direct target). Fails closed.
- `session_regularized_training.py`: optional `bottleneck_sparsity_fn` merged into the per-step loss log payload.
- `disrnn_trainer.py`: threads it through the main-phase calls (`log_bottleneck_sparsity=True`), adds the step-0 baseline, keeps the `final/bottlenecks/*` summary write.

Validated on real JAX params (smoke): step-0 `frac_open=1.0`, 38 bottleneck history keys logging per ~10 steps.