### PR TITLE
feat(disrnn): length-bucketed batching + trainer-agnostic extend-later restore

### DIFF
--- a/beaker/README.md
+++ b/beaker/README.md
@@ -354,6 +354,33 @@ that work make kernels **fatter or concurrent**:
   cuts the deep-chain launch overhead.
 - **MPS** — lets separate processes' kernels share SMs (would rescue packing).
 
+**Length-bucketed batching — shortens the deep chain (opt-in, `training.length_bucketing`).**
+A separate lever from the three above: it doesn't make kernels *fatter*, it makes the
+*sequential chain shorter*. Sessions are RNN-unrolled over the trial axis, padded to the
+global `T_max` (≈1488 trials for the 100-mice snapshot), but real session lengths vary
+widely (≈438–857). Every padding row is a full recurrent step — pure wasted compute on the
+deep/sequential axis that dominates our runtime. With bucketing on, each `random`-mode batch
+is drawn from a **single length bucket** (sessions grouped by real length rounded up to
+`length_bucket_grid`, default 128) and the unroll is **trimmed** to that bucket's length, so
+short-session batches run far fewer sequential steps. Correctness: trimming only drops
+all-padding rows (real length ≤ bucket length), so loss/mask are unchanged. Cost: one JAX
+recompile per distinct bucket length (≈`T_max/grid` ≈ 12 shapes), amortized over training.
+
+- **Where it runs — the TRAINING loop, not rollout/generation.** The trim happens in
+  `_sample_batch` (`utils/session_regularized_training.py`), called each step inside
+  `train_network_with_session_regularization` immediately before the gradient `train_step`
+  — the shared training loop used by **both** the GRU and disRNN trainers. It is *not* a
+  generative-rollout or distillation feature (those have their own batching). So bucketing
+  reduces the compute of every gradient step, at both trainers' train time.
+- **Requires `batch_mode: random`** (the bucketed branch only fires there) and a set
+  `batch_size`. No-op under `single`/full-batch. Wired per-trainer by setting
+  `dataset_train.length_bucketing` — `gru_trainer.py` (long-standing) and `disrnn_trainer.py`
+  (added 2026-07) both do this from the `training.length_bucketing` config key.
+- **Caveat:** each batch is length-homogeneous, so the per-step gradient is over sessions of
+  similar length rather than a uniform draw across all lengths; per-bucket sampling weights
+  keep it ≈uniform over sessions in expectation. Keep the setting fixed across a grid so
+  cells stay comparable.
+
 **Decision (current): `vmap` is shelved.** `replicas` across GPUs (done) plus a bigger
 `batch_size`/`num_sessions` (free, science permitting) capture most of the per-GPU
 headroom; `vmap` is a costly, correctness-sensitive core rewrite (the loss is a closure

--- a/beaker/README.md
+++ b/beaker/README.md
@@ -366,6 +366,20 @@ short-session batches run far fewer sequential steps. Correctness: trimming only
 all-padding rows (real length ≤ bucket length), so loss/mask are unchanged. Cost: one JAX
 recompile per distinct bucket length (≈`T_max/grid` ≈ 12 shapes), amortized over training.
 
+**Measured (2026-07): ~1.86× throughput on disRNN.** Matched runs (100-mice snapshot,
+`lr=1e-3`, `beta=1e-3`, L40s/g6e, `random`/2048 batch — the *only* difference is bucketing),
+from W&B `_step`/`_timestamp`:
+
+| | ms/step | steps/s |
+|---|---:|---:|
+| No bucketing | 2015 | 0.496 |
+| `length_bucketing`, grid=128 | 1083 | 0.924 |
+
+The bucketed figure is measured over steps 0–1499, so it *includes* the per-bucket JIT
+compiles — steady-state is marginally better. This is the one lever that actually moved
+disRNN throughput (batch size and GPU packing both plateaued near 1.15×), because our
+session-length distribution is wide, so most of each step's compute was padding rows.
+
 - **Where it runs — the TRAINING loop, not rollout/generation.** The trim happens in
   `_sample_batch` (`utils/session_regularized_training.py`), called each step inside
   `train_network_with_session_regularization` immediately before the gradient `train_step`

--- a/beaker/README.md
+++ b/beaker/README.md
@@ -279,6 +279,34 @@ Consequences:
 - **Rebuild only on dependency changes** (`pyproject.toml` / pinned git deps).
   Symptom: a run fails with `ImportError` / `ModuleNotFoundError` after a pull.
 
+## 3b. Staged horizons — "extend later" (continue from a prior run)
+
+Two resume mechanisms exist; they compose:
+
+- **Preemption resume (automatic, within one experiment).** A preempted
+  low-priority task restarts as the *same* task with the *same* `/results`
+  dataset; the trainer re-finds `outputs/checkpoints/step_<N>/train_state.pkl`
+  (`checkpoint_resume.find_latest_resumable_state`) and continues, skipping
+  warmup. Requires `checkpoint_every_n_steps > 0` and `auto_resume: true`
+  (default). W&B continuity via a deterministic `WANDB_RUN_ID` + `WANDB_RESUME`.
+
+- **Extend later (opt-in, across experiments).** Launch a grid at a *short*
+  `n_steps` to get all cells to an interpretable point fast, then relaunch a
+  *continuation* experiment at a larger `n_steps` that **continues each cell
+  from the short run's checkpoint** instead of restarting. Set
+  **`model.training.restore_from_run_id`** (or env `DISRNN_RESTORE_FROM_RUN_ID`
+  — env wins, so a sweep can pass a per-cell id) to the source run's W&B id.
+  Before training, `run_hpc.py` downloads that run's `training-output` artifact
+  (`<mtype>-output-<run_id>`; `mtype` ∈ {`disrnn`,`gru`}) into this run's
+  `outputs/`, so its `checkpoints/` land where the trainer resumes from — warmup
+  is skipped. **Trainer-agnostic:** both disRNN and GRU upload the whole
+  `output_dir` and resume via the shared `checkpoint_resume`, so the same knob
+  works for either. Only seeds when no local checkpoint exists yet (a preemption
+  restart of the continuation run keeps its fresher local state). Fails **loudly**
+  if the source artifact is missing — it never silently restarts from scratch.
+  The larger `n_steps` must exceed the source's, since the trainer loops
+  `while steps_completed < n_steps`.
+
 ## 4. Where to change what
 
 | Want to change… | Edit | Rebuild image? |

--- a/code/model_trainers/disrnn_trainer.py
+++ b/code/model_trainers/disrnn_trainer.py
@@ -762,6 +762,25 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
             metadata=metadata,
         )
 
+        # --- Length-bucketed batching (opt-in via training.length_bucketing) ---
+        # Trim the per-batch unroll to the batch's session length instead of the
+        # global T_max, cutting padding compute. The bucketed-sampling logic lives
+        # in the shared _sample_batch (utils/session_regularized_training.py); it
+        # only fires when the train dataset carries `length_bucketing=True` and
+        # batch_mode == "random". Mirrors gru_trainer.py's wiring so both trainers
+        # share one implementation. Set on the train dataset that session-
+        # regularized training samples from (after the session-index prepend so
+        # feature-0 padding markers are already in place).
+        if bool(self.training.get("length_bucketing", False)):
+            dataset_train.length_bucketing = True
+            dataset_train.length_bucket_grid = int(
+                self.training.get("length_bucket_grid", 128)
+            )
+            logger.info(
+                "Length-bucketed batching enabled (grid=%s)",
+                dataset_train.length_bucket_grid,
+            )
+
         total_session_curriculum_steps = int(self.training.get("n_warmup_steps", 0)) + int(
             self.training.get("n_steps", 0)
         )

--- a/code/run_hpc.py
+++ b/code/run_hpc.py
@@ -23,6 +23,7 @@ from utils.run_helpers import (
     configure_sys_logger,
     copy_inputs_for_run,
     copy_run_to_wandb,
+    maybe_restore_checkpoint_from_wandb,
     save_resolved_config,
     start_wandb_run,
 )
@@ -91,6 +92,13 @@ def main(hydra_config: DictConfig) -> None:
     if hasattr(hydra_config, "model") and "output_dir" in hydra_config.model:
         hydra_config.model.output_dir = str(run_output_base / "outputs")
         logger.info("Model output_dir set to %s", hydra_config.model.output_dir)
+
+    # Extend-later: if training.restore_from_run_id (or DISRNN_RESTORE_FROM_RUN_ID)
+    # is set, seed this run's output dir from that prior run's W&B checkpoint
+    # artifact so the trainer continues from it (skips warmup) instead of starting
+    # fresh. Trainer-agnostic; no-op when not requested; only seeds when no local
+    # checkpoint exists yet (preemption-restart safe). See run_helpers docstring.
+    maybe_restore_checkpoint_from_wandb(hydra_config, run_output_base)
 
     resolved_yaml = OmegaConf.to_yaml(hydra_config, resolve=True)
     logger.info("Hydra config (resolved):\n%s", resolved_yaml)

--- a/code/utils/run_helpers.py
+++ b/code/utils/run_helpers.py
@@ -420,3 +420,109 @@ def compute_bottleneck_sparsity_metrics(
     except Exception as exc:  # noqa: BLE001
         logger.warning("compute_bottleneck_sparsity_metrics failed: %s", exc)
         return {}
+
+
+def maybe_restore_checkpoint_from_wandb(
+    hydra_config: DictConfig,
+    run_output_base: Path,
+) -> None:
+    """Seed a NEW run's output dir from a prior run's W&B checkpoint artifact.
+
+    Enables a *staged-horizon* / *extend-later* workflow: launch a grid at a
+    short ``n_steps``, then relaunch a continuation experiment with a larger
+    ``n_steps`` that CONTINUES each cell from where the short run stopped instead
+    of restarting from scratch.
+
+    Mechanism (trainer-agnostic — works for disRNN and GRU, since both upload the
+    whole ``output_dir`` as artifact ``<mtype>-output-<run_id>`` via
+    ``add_dir`` and both resume from ``<output_dir>/checkpoints`` via the shared
+    ``checkpoint_resume.find_latest_resumable_state``):
+
+      1. Read the source run id from ``training.restore_from_run_id`` (or the
+         ``DISRNN_RESTORE_FROM_RUN_ID`` env var — env wins, so a sweep can pass
+         a per-cell id without editing config).
+      2. Download artifact ``<entity>/<project>/<mtype>-output-<run_id>:latest``
+         into ``<run_output_base>/outputs`` so its ``checkpoints/step_<N>/``
+         subtree lands exactly where the trainer looks. Resume then SKIPS warmup
+         (warmup is folded into the checkpointed params).
+
+    SAFETY — only seeds when there is NO local checkpoint yet. On a preemption
+    restart of the *continuation* run, the local ``checkpoints/`` are FRESHER
+    than the seed artifact, so we must not overwrite them; this makes the restore
+    a one-time seed that composes correctly with Beaker autoResume.
+
+    Fails LOUDLY (raises) when a restore is requested but the artifact cannot be
+    found/downloaded — a silent restart-from-scratch would waste the whole point.
+    A no-op when no ``restore_from_run_id`` is set.
+    """
+    run_id = os.environ.get("DISRNN_RESTORE_FROM_RUN_ID")
+    if not run_id:
+        try:
+            run_id = hydra_config.model.training.get("restore_from_run_id")
+        except Exception:  # noqa: BLE001
+            run_id = None
+    if not run_id:
+        return  # extend-later not requested; normal fresh run
+
+    run_id = str(run_id).strip()
+    outputs_dir = Path(run_output_base) / "outputs"
+    checkpoints_dir = outputs_dir / "checkpoints"
+
+    # Preemption-restart guard: a local checkpoint already exists (this run has
+    # made progress), so autoResume owns the state -- do NOT re-seed.
+    if checkpoints_dir.is_dir() and any(checkpoints_dir.glob("step_*")):
+        logger.info(
+            "restore_from_run_id=%s requested, but local checkpoints already "
+            "exist at %s -- skipping restore (autoResume owns the state).",
+            run_id,
+            checkpoints_dir,
+        )
+        return
+
+    entity = None
+    project = None
+    try:
+        entity = hydra_config.wandb.get("entity")
+        project = hydra_config.wandb.get("project")
+    except Exception:  # noqa: BLE001
+        pass
+    if not entity or not project:
+        raise ValueError(
+            "restore_from_run_id set but wandb.entity/wandb.project are missing; "
+            "cannot locate the source checkpoint artifact."
+        )
+
+    mtype = str(hydra_config.model.type)
+    artifact_ref = f"{entity}/{project}/{mtype}-output-{run_id}:latest"
+    logger.info(
+        "Extend-later: restoring checkpoint from artifact %s into %s",
+        artifact_ref,
+        outputs_dir,
+    )
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        api = wandb.Api()
+        artifact = api.artifact(artifact_ref, type="training-output")
+        artifact.download(root=str(outputs_dir))
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(
+            f"Extend-later restore FAILED for artifact {artifact_ref!r}: {exc}. "
+            "Refusing to silently restart from scratch. Check the source run id, "
+            "that its run finished uploading its training-output artifact, and "
+            "that wandb.entity/project match the source project."
+        ) from exc
+
+    steps = sorted(checkpoints_dir.glob("step_*")) if checkpoints_dir.is_dir() else []
+    if not steps:
+        raise RuntimeError(
+            f"Extend-later restore downloaded {artifact_ref!r} but found no "
+            f"checkpoints/step_* under {outputs_dir}. The source artifact may not "
+            "contain resumable state (needs checkpoint_every_n_steps>0 on the "
+            "source run)."
+        )
+    logger.info(
+        "Extend-later: restored %d checkpoint(s); latest=%s. Training will "
+        "resume from it and skip warmup.",
+        len(steps),
+        steps[-1].name,
+    )


### PR DESCRIPTION
## Summary
Adds two trainer-side capabilities on top of the real-time bottleneck-sparsity logging (already merged via #45):

1. **Length-bucketed batching for disRNN** — wires `training.length_bucketing` (+ `length_bucket_grid`, default 128) to the shared `_sample_batch`, mirroring `gru_trainer.py`. Trims each `random`-mode training batch's unroll from the global `T_max` (≈1488) to the batch's own session length, dropping wasted padding-row recurrent steps. **Measured ~1.86× throughput** on the 100-mice disRNN (2015 → 1083 ms/step, matched config). No-op unless the config key is set.
2. **Extend-later checkpoint restore (staged horizons)** — new `run_helpers.maybe_restore_checkpoint_from_wandb`, called from `run_hpc.py` before training. When `training.restore_from_run_id` (or env `DISRNN_RESTORE_FROM_RUN_ID`) is set, downloads the source run's `<mtype>-output-<run_id>` W&B artifact into `outputs/` so the trainer resumes from its checkpoint (skips warmup) instead of restarting. **Trainer-agnostic** (disRNN + GRU both upload `output_dir` and resume via the shared `checkpoint_resume`). Preemption-safe (only seeds when no local checkpoint exists); fails loudly if the artifact is missing.

## Why
Enables a staged-horizon workflow: launch a grid at a short `n_steps` for early information, then extend only promising cells to a longer horizon by continuing from checkpoints rather than re-burning compute. Length bucketing is the one lever that actually moved disRNN throughput (batch size and GPU packing both plateaued ~1.15×).

## Files
- `code/model_trainers/disrnn_trainer.py` (+19) — length-bucketing wiring
- `code/utils/run_helpers.py` (+106) — restore helper
- `code/run_hpc.py` (+8) — call the restore hook
- `beaker/README.md` — §3b staged-horizon docs + Performance-notes length-bucketing lever (with measured numbers)

## Verification
Smoke run confirmed: config resolves with `length_bucketing: true`, `Length-bucketed batching enabled (grid=128)` logs, training advances through the bucketed main phase (checkpoint at step 1000, likelihood 0.71), ~1.86× speedup measured. Docs-only commits `5f4f51c`/`842f6e5`; feature commit `87d93f8c`.
