### PR TITLE
feat(heldout): 3-way ignore-class metrics + exact held-out re-score

### DIFF
--- a/code/evaluation/gru_evaluation.py
+++ b/code/evaluation/gru_evaluation.py
@@ -272,7 +272,16 @@ def plot_gru_examples_for_split(
             logits[:, :, :n_action_logits],
             class_index=1 if n_action_logits > 1 else 0,
         )
-        color_label = "P(right)" if n_action_logits == 2 else "P(class_1)"
+        color_label = "P(right)" if n_action_logits == 2 else "P(right)"
+        # For the 3-way (ignore-included) head, also color the SAME latent space
+        # by P(ignore) so the engage/disengage axis is visible alongside the L/R
+        # axis. Class index 2 = ignore (0=left, 1=right, 2=ignore).
+        engage_probs_for_coloring = None
+        if n_action_logits >= 3:
+            engage_probs_for_coloring = _prob_from_logits(
+                logits[:, :, :n_action_logits],
+                class_index=2,
+            )
         selected_latents = list(range(projected_states.shape[2]))
         run_len = min(30, states.shape[0])
 
@@ -283,6 +292,7 @@ def plot_gru_examples_for_split(
         selected_examples: list[dict[str, Any]] = []
         trial_plot_paths: list[Path] = []
         space_plot_paths: list[Path] = []
+        engage_space_plot_paths: list[Path] = []
 
         for subject_id, session_ids in subject_groups:
             selected_session_ids = session_ids[:sessions_per_subject]
@@ -315,6 +325,27 @@ def plot_gru_examples_for_split(
                 split_dir / f"latents_in_space_subject_{_safe_filename_component(subject_id)}.png",
             )
             space_plot_paths.append(subject_space_plot_path)
+
+            # Engagement (P(ignore)) view of the same latent space, 3-way only.
+            if engage_probs_for_coloring is not None:
+                subject_engage_colors = engage_probs_for_coloring[:, session_indices]
+                subject_engage_color_points = subject_engage_colors.reshape(-1)
+                fig_engage = plot_latents_in_space(
+                    latent_states=subject_states_points,
+                    color_values=subject_engage_color_points,
+                    color_label="P(ignore)",
+                    selected_latents=selected_latents,
+                    example_run=example_run,
+                    axis_label_prefix="PC",
+                )
+                fig_engage.suptitle(str(_normalize_identifier(session_ids[0])), fontsize=14)
+                fig_engage.subplots_adjust(top=0.93)
+                subject_engage_plot_path = save_figure(
+                    fig_engage,
+                    split_dir
+                    / f"latents_in_space_engage_subject_{_safe_filename_component(subject_id)}.png",
+                )
+                engage_space_plot_paths.append(subject_engage_plot_path)
 
             for session_id in selected_session_ids:
                 session_df = output_df[output_df["ses_idx"] == session_id].sort_values("trial")
@@ -379,6 +410,9 @@ def plot_gru_examples_for_split(
             "plots": {
                 "latents_over_trials_examples": [str(p) for p in trial_plot_paths],
                 "latents_in_space_examples": [str(p) for p in space_plot_paths],
+                "latents_in_space_engage_examples": [
+                    str(p) for p in engage_space_plot_paths
+                ],
             },
         }
     except Exception as exc:
@@ -411,12 +445,19 @@ def plot_gru_examples_for_split(
             wandb.Image(str(path))
             for path in summary["plots"]["latents_in_space_examples"]
         ]
-        wandb_run.log(
-            {
-                f"{split_name}/latents_over_trials_examples": wandb_trial_images,
-                f"{split_name}/latents_in_space_examples": wandb_space_images,
-            }
-        )
+        wandb_engage_images = [
+            wandb.Image(str(path))
+            for path in summary["plots"].get("latents_in_space_engage_examples", [])
+        ]
+        space_log = {
+            f"{split_name}/latents_over_trials_examples": wandb_trial_images,
+            f"{split_name}/latents_in_space_examples": wandb_space_images,
+        }
+        if wandb_engage_images:
+            space_log[f"{split_name}/latents_in_space_engage_examples"] = (
+                wandb_engage_images
+            )
+        wandb_run.log(space_log)
 
     return summary
 
@@ -625,11 +666,19 @@ def evaluate_gru_on_heldout_subjects(
             np.asarray(yhat_test)[:, :, :n_action_logits],
             class_index=prob_class_index,
         )
-        color_label = "P(right)" if n_action_logits == 2 else f"P(class_{prob_class_index})"
+        color_label = "P(right)"
+        # Engagement (P(ignore)) coloring for the 3-way head (2 = ignore).
+        engage_probs_for_coloring = None
+        if n_action_logits >= 3:
+            engage_probs_for_coloring = _prob_from_logits(
+                np.asarray(yhat_test)[:, :, :n_action_logits],
+                class_index=2,
+            )
         selected_latents = list(range(projected_states.shape[2]))
         run_len = min(30, projected_states.shape[0])
 
         space_plot_paths: list[Path] = []
+        engage_space_plot_paths: list[Path] = []
         for subject_id, subject_rows in selected_subject_groups:
             subject_sessions = subject_rows["ses_idx"].tolist()
             session_indices = [
@@ -667,6 +716,29 @@ def evaluate_gru_on_heldout_subjects(
             )
             space_plot_paths.append(subject_space_plot_path)
 
+            if engage_probs_for_coloring is not None:
+                subject_engage_colors = engage_probs_for_coloring[:, session_indices]
+                subject_engage_color_points = subject_engage_colors.reshape(-1)
+                fig_engage = plot_latents_in_space(
+                    latent_states=subject_states_points,
+                    color_values=subject_engage_color_points,
+                    color_label="P(ignore)",
+                    selected_latents=selected_latents,
+                    example_run=example_run,
+                    axis_label_prefix="PC",
+                )
+                fig_engage.suptitle(
+                    str(_normalize_identifier(example_session_id)),
+                    fontsize=14,
+                )
+                fig_engage.subplots_adjust(top=0.93)
+                subject_engage_plot_path = save_figure(
+                    fig_engage,
+                    plot_dir
+                    / f"latents_in_space_engage_subject_{_safe_filename_component(subject_id)}.png",
+                )
+                engage_space_plot_paths.append(subject_engage_plot_path)
+
         if not space_plot_paths:
             raise ValueError("Could not generate held-out latent-space plots for any subject.")
 
@@ -689,6 +761,9 @@ def evaluate_gru_on_heldout_subjects(
             "plots": {
                 "latents_over_trials_examples": [str(p) for p in trial_plot_paths],
                 "latents_in_space_examples": [str(p) for p in space_plot_paths],
+                "latents_in_space_engage_examples": [
+                    str(p) for p in engage_space_plot_paths
+                ],
             },
         }
     except Exception as exc:
@@ -734,11 +809,20 @@ def evaluate_gru_on_heldout_subjects(
                 wandb.Image(str(path))
                 for path in summary["plots"]["latents_in_space_examples"]
             ]
-            wandb_run.log(
-                {
-                    "heldout/latents_over_trials_examples": wandb_trial_images,
-                    "heldout/latents_in_space_examples": wandb_space_images,
-                }
-            )
+            wandb_engage_images = [
+                wandb.Image(str(path))
+                for path in summary["plots"].get(
+                    "latents_in_space_engage_examples", []
+                )
+            ]
+            heldout_space_log = {
+                "heldout/latents_over_trials_examples": wandb_trial_images,
+                "heldout/latents_in_space_examples": wandb_space_images,
+            }
+            if wandb_engage_images:
+                heldout_space_log["heldout/latents_in_space_engage_examples"] = (
+                    wandb_engage_images
+                )
+            wandb_run.log(heldout_space_log)
 
     return summary

--- a/code/evaluation/gru_evaluation.py
+++ b/code/evaluation/gru_evaluation.py
@@ -319,7 +319,6 @@ def plot_gru_examples_for_split(
                 axis_label_prefix="PC",
             )
             fig_space.suptitle(str(_normalize_identifier(session_ids[0])), fontsize=14)
-            fig_space.subplots_adjust(top=0.93)
             subject_space_plot_path = save_figure(
                 fig_space,
                 split_dir / f"latents_in_space_subject_{_safe_filename_component(subject_id)}.png",
@@ -339,7 +338,6 @@ def plot_gru_examples_for_split(
                     axis_label_prefix="PC",
                 )
                 fig_engage.suptitle(str(_normalize_identifier(session_ids[0])), fontsize=14)
-                fig_engage.subplots_adjust(top=0.93)
                 subject_engage_plot_path = save_figure(
                     fig_engage,
                     split_dir
@@ -708,7 +706,6 @@ def evaluate_gru_on_heldout_subjects(
                 str(_normalize_identifier(example_session_id)),
                 fontsize=14,
             )
-            fig_space.subplots_adjust(top=0.93)
             subject_space_plot_path = save_figure(
                 fig_space,
                 plot_dir
@@ -731,7 +728,6 @@ def evaluate_gru_on_heldout_subjects(
                     str(_normalize_identifier(example_session_id)),
                     fontsize=14,
                 )
-                fig_engage.subplots_adjust(top=0.93)
                 subject_engage_plot_path = save_figure(
                     fig_engage,
                     plot_dir

--- a/code/evaluation/plotting.py
+++ b/code/evaluation/plotting.py
@@ -296,7 +296,10 @@ def plot_latents_in_space(
 
                 ax_id += 1
 
-    fig.tight_layout()
+    # Reserve headroom so a caller-added suptitle (e.g. the session id) does not
+    # overlap the per-axis "Latent space trajectory" titles. tight_layout with a
+    # rect top < 1 packs the axes below the reserved band.
+    fig.tight_layout(rect=(0.0, 0.0, 1.0, 0.92))
     return fig
 
 

--- a/code/model_trainers/base_multisubject_trainer.py
+++ b/code/model_trainers/base_multisubject_trainer.py
@@ -756,6 +756,14 @@ class BaseMultisubjectTrainer(ModelTrainer):
             image_payload[f"{wandb_key_prefix}/heldout/latents_in_space_examples"] = [
                 wandb.Image(str(path)) for path in space_plot_paths
             ]
+        engage_plot_paths = heldout_summary.get("plots", {}).get(
+            "latents_in_space_engage_examples",
+            [],
+        )
+        if engage_plot_paths:
+            image_payload[
+                f"{wandb_key_prefix}/heldout/latents_in_space_engage_examples"
+            ] = [wandb.Image(str(path)) for path in engage_plot_paths]
         if image_payload:
             if wandb_step is None:
                 wandb_run.log(image_payload)
@@ -997,6 +1005,16 @@ class BaseMultisubjectTrainer(ModelTrainer):
                         )
                     ],
                 }
+                # 3-way (ignore-included) head: also log the P(ignore)-colored
+                # engagement panel when the split plotter produced it. Absent for a
+                # 2-way head, so the key is only added when non-empty.
+                engage_paths = split_summary.get("plots", {}).get(
+                    "latents_in_space_engage_examples", []
+                )
+                if engage_paths:
+                    payload[f"{key_prefix}/latents_in_space_engage_examples"] = [
+                        wandb.Image(str(path)) for path in engage_paths
+                    ]
                 if wandb_step is None:
                     wandb_run.log(payload)
                 else:

--- a/code/model_trainers/gru_trainer.py
+++ b/code/model_trainers/gru_trainer.py
@@ -267,6 +267,45 @@ def _threeway_likelihood_decomposition(
             rnn_utils.normalized_likelihood(engage_label, binary_logits)
         )
 
+        # --- Ignore-class classification metrics (rare positive: ~5% of trials) ---
+        # Likelihood alone is dominated by the ~95% engaged majority and cannot
+        # tell genuine ignore-detection from base-rate hedging. Report class-
+        # resolved precision/recall/F1 (at p=0.5) and threshold-free average
+        # precision (PR-AUC) with ignore as the positive class.
+        vmask = valid.reshape(-1)
+        y_true = (lab.reshape(-1)[vmask] == _IGNORE_CLASS_INDEX).astype(np.int64)
+        # P(ignore) from the binary head: softmax over [engaged, ignore].
+        bl = binary_logits.reshape(-1, 2)[vmask]
+        bl_max = np.max(bl, axis=-1, keepdims=True)
+        bexp = np.exp(bl - bl_max)
+        p_ignore = (bexp[:, 1] / bexp.sum(axis=-1))
+        n_pos = int(y_true.sum())
+        n_tot = int(y_true.size)
+        out["engage_ignore_base_rate"] = float(n_pos / n_tot) if n_tot else 0.0
+        if n_pos > 0:
+            pred = (p_ignore >= 0.5).astype(np.int64)
+            tp = float(np.sum((pred == 1) & (y_true == 1)))
+            fp = float(np.sum((pred == 1) & (y_true == 0)))
+            fn = float(np.sum((pred == 0) & (y_true == 1)))
+            prec = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+            rec = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+            f1 = (2 * prec * rec / (prec + rec)) if (prec + rec) > 0 else 0.0
+            out["engage_ignore_precision"] = float(prec)
+            out["engage_ignore_recall"] = float(rec)
+            out["engage_ignore_f1"] = float(f1)
+            # Average precision (area under PR curve), threshold-free. No-skill
+            # baseline == base rate, so lift over base_rate is what matters.
+            order = np.argsort(-p_ignore)
+            yt = y_true[order]
+            tps = np.cumsum(yt)
+            fps = np.cumsum(1 - yt)
+            precisions = tps / np.maximum(tps + fps, 1)
+            recalls = tps / n_pos
+            rec_prev = np.concatenate([[0.0], recalls[:-1]])
+            out["engage_ignore_pr_auc"] = float(
+                np.sum((recalls - rec_prev) * precisions)
+            )
+
     return out
 
 

--- a/code/model_trainers/gru_trainer.py
+++ b/code/model_trainers/gru_trainer.py
@@ -204,6 +204,78 @@ def _require_n_action_logits(dataset: Any, yhat: np.ndarray, *, context: str) ->
     return n_action_logits
 
 
+# Class-index convention for the 3-way (ignore-included) head: 0=left, 1=right,
+# 2=ignore. Matches the data loader (animal_response) and the L/R prob columns
+# in gru_evaluation. For the 2-way head only classes 0/1 exist.
+_IGNORE_CLASS_INDEX = 2
+
+
+def _threeway_likelihood_decomposition(
+    labels: np.ndarray,
+    logits: np.ndarray,
+    *,
+    n_action_logits: int,
+) -> dict[str, float]:
+    """Decompose a 3-way (L/R/ignore) eval into engagement-relevant metrics.
+
+    The raw 3-way normalized likelihood lives on a 1/3-chance scale and is NOT
+    comparable to the 2-way study's L/R numbers (1/2-chance, engaged trials
+    only). This returns two extra scalars that ARE interpretable:
+
+    - ``eval_likelihood_LR_engaged``: geometric-mean likelihood of the correct
+      side (left/right) on ENGAGED trials only, with the softmax renormalized
+      over the {left, right} logits. Directly comparable to the 2-way L/R
+      likelihood. Implemented by masking non-engaged labels to -1 (the
+      convention ``normalized_likelihood`` uses for padding) and slicing the
+      logits to the first two classes, so log_softmax renormalizes over L/R.
+    - ``eval_likelihood_engage``: geometric-mean likelihood of the correct
+      engage-vs-ignore decision, over ALL trials, by collapsing the head to a
+      binary {engaged, ignore} problem (engaged logit = logsumexp of L,R).
+
+    Returns an empty dict for a 2-way head (nothing to decompose).
+    """
+    labels = np.asarray(labels)
+    logits = np.asarray(logits)
+    if n_action_logits < 3 or logits.shape[2] < 3:
+        return {}
+
+    lab = labels[..., 0].astype(np.int64)  # (T, E)
+    valid = lab >= 0  # padding mask used by normalized_likelihood
+
+    out: dict[str, float] = {}
+
+    # --- Conditional L/R on engaged trials (comparable to the 2-way number) ---
+    engaged = valid & (lab != _IGNORE_CLASS_INDEX)
+    if bool(engaged.any()):
+        lr_labels = np.where(engaged, lab, -1)[..., None]  # mask ignore -> -1
+        lr_logits = logits[:, :, :2]  # renormalize softmax over {L, R}
+        out["eval_likelihood_LR_engaged"] = float(
+            rnn_utils.normalized_likelihood(lr_labels, lr_logits)
+        )
+
+    # --- Engage vs ignore (binary calibration of the ignore head) ---
+    if bool(valid.any()):
+        # Binary label: 0 = engaged (was L or R), 1 = ignore.
+        engage_label = np.where(lab == _IGNORE_CLASS_INDEX, 1, 0)
+        engage_label = np.where(valid, engage_label, -1)[..., None]
+        # Binary logits: [engaged = logsumexp(L, R), ignore].
+        lr_logits = logits[:, :, :2]
+        engaged_logit = _logsumexp(lr_logits, axis=-1)  # (T, E)
+        ignore_logit = logits[:, :, _IGNORE_CLASS_INDEX]  # (T, E)
+        binary_logits = np.stack([engaged_logit, ignore_logit], axis=-1)
+        out["eval_likelihood_engage"] = float(
+            rnn_utils.normalized_likelihood(engage_label, binary_logits)
+        )
+
+    return out
+
+
+def _logsumexp(a: np.ndarray, axis: int) -> np.ndarray:
+    a_max = np.max(a, axis=axis, keepdims=True)
+    out = np.log(np.sum(np.exp(a - a_max), axis=axis, keepdims=True)) + a_max
+    return np.squeeze(out, axis=axis)
+
+
 def _bind_session_curriculum_lambda(
     make_network: Any,
     *,
@@ -964,6 +1036,7 @@ class GruTrainer(BaseMultisubjectTrainer):
                     )
 
                 eval_likelihood_ckpt: float | None = None
+                eval_likelihood_decomp_ckpt: dict[str, float] = {}
                 if args.checkpoint_eval_on_eval_split:
                     yhat_eval_ckpt, _ = self._eval_network_full(
                         current_eval_network,
@@ -980,6 +1053,14 @@ class GruTrainer(BaseMultisubjectTrainer):
                             ys_eval_all,
                             np.asarray(yhat_eval_ckpt)[:, :, :n_action_logits_ckpt],
                         )
+                    )
+                    # For the 3-way (ignore-included) head, also record the
+                    # engagement-conditional L/R likelihood (comparable to the
+                    # 2-way study) and the engage-vs-ignore calibration.
+                    eval_likelihood_decomp_ckpt = _threeway_likelihood_decomposition(
+                        ys_eval_all,
+                        np.asarray(yhat_eval_ckpt)[:, :, :n_action_logits_ckpt],
+                        n_action_logits=n_action_logits_ckpt,
                     )
 
                 checkpoint_record = {
@@ -1000,6 +1081,14 @@ class GruTrainer(BaseMultisubjectTrainer):
                         "Checkpoint step %s, eval likelihood: %.4f",
                         steps_completed,
                         eval_likelihood_ckpt,
+                    )
+                for _decomp_key, _decomp_val in eval_likelihood_decomp_ckpt.items():
+                    checkpoint_record[_decomp_key] = _decomp_val
+                    logger.info(
+                        "Checkpoint step %s, %s: %.4f",
+                        steps_completed,
+                        _decomp_key,
+                        _decomp_val,
                     )
 
                 checkpoint_plot_paths: dict[str, Any] = {
@@ -1135,6 +1224,10 @@ class GruTrainer(BaseMultisubjectTrainer):
                         {
                             "checkpoint/eval_likelihood": eval_likelihood_ckpt,
                             "checkpoint/step": int(steps_completed),
+                            **{
+                                f"checkpoint/{_k}": _v
+                                for _k, _v in eval_likelihood_decomp_ckpt.items()
+                            },
                         },
                         step=int(steps_completed),
                     )

--- a/code/post_training_analysis/heldout_finetuning.py
+++ b/code/post_training_analysis/heldout_finetuning.py
@@ -29,7 +29,7 @@ from base.types import DatasetBundle
 from data_loaders import mice as mice_loader
 from disentangled_rnns.library import rnn_utils
 from model_trainers.disrnn_trainer import DisrnnTrainer
-from model_trainers.gru_trainer import GruTrainer
+from model_trainers.gru_trainer import GruTrainer, _threeway_likelihood_decomposition
 from models.gru_network import make_gru_network
 from models.session_conditioning import resolve_session_conditioning_from_architecture
 from post_training_analysis.generative_analysis import resolve_model_run
@@ -1278,6 +1278,16 @@ def _evaluate_checkpoint(
         "train_likelihood": float(train_likelihood),
         "eval_likelihood": float(eval_likelihood),
     }
+    # For the 3-way (ignore-included) head, also record the engagement-conditional
+    # L/R held-out likelihood (comparable to the 2-way study's held-out number) and
+    # the engage-vs-ignore held-out calibration. No-op for a 2-way head.
+    eval_likelihood_decomp = _threeway_likelihood_decomposition(
+        ys_eval,
+        np.asarray(yhat_eval_eval)[:, :, :eval_n_action_logits],
+        n_action_logits=eval_n_action_logits,
+    )
+    for _decomp_key, _decomp_val in eval_likelihood_decomp.items():
+        record[_decomp_key] = float(_decomp_val)
     record["per_subject_likelihood"] = _compute_per_subject_eval_likelihood(
         ys_eval=ys_eval,
         yhat_eval=np.asarray(yhat_eval_eval)[:, :, :eval_n_action_logits],
@@ -1403,12 +1413,18 @@ def _final_metrics_summary(checkpoint_records: Sequence[Mapping[str, Any]]) -> d
     if not checkpoint_records:
         return {}
     final_record = checkpoint_records[-1]
-    return {
+    summary = {
         "train_loss": float(final_record["train_loss"]),
         "eval_loss": float(final_record["eval_loss"]),
         "train_likelihood": float(final_record["train_likelihood"]),
         "eval_likelihood": float(final_record["eval_likelihood"]),
     }
+    # Propagate the 3-way decomposition (engagement-conditional L/R, engage-vs-
+    # ignore) to heldout/final/* if present. No-op for a 2-way head.
+    for _k in ("eval_likelihood_LR_engaged", "eval_likelihood_engage"):
+        if _k in final_record:
+            summary[_k] = float(final_record[_k])
+    return summary
 
 
 def run_heldout_subject_finetuning_from_config(
@@ -1681,6 +1697,14 @@ def run_heldout_subject_finetuning_from_config(
                             checkpoint_record["eval_likelihood"]
                         ),
                         f"{wandb_log_key_prefix}/step": int(step),
+                        **{
+                            f"{wandb_log_key_prefix}/{_k}": float(checkpoint_record[_k])
+                            for _k in (
+                                "eval_likelihood_LR_engaged",
+                                "eval_likelihood_engage",
+                            )
+                            if _k in checkpoint_record
+                        },
                     },
                     step=checkpoint_wandb_step,
                 )

--- a/code/post_training_analysis/heldout_finetuning.py
+++ b/code/post_training_analysis/heldout_finetuning.py
@@ -382,7 +382,19 @@ def _resolve_output_run_dir(
     heldout_selector: Mapping[str, Any],
 ) -> Path:
     output_root = Path(resolved_config["output"]["output_root"]).expanduser().resolve()
-    source_run_slug = _safe_slug(Path(source_run.model_dir).name)
+    # The source model_dir follows the W&B layout ``.../run-<id>/files``, so
+    # ``Path(model_dir).name`` is the constant string "files" (likewise "results"/
+    # "outputs" for other layouts) and the unique run id lives in the PARENT dir.
+    # Using only .name made every concurrent grid cell share one held-out output
+    # path on a shared filesystem (HPC scratch), so a second cell's rebuild could
+    # read a first cell's config -> architecture/shape mismatch. Fold in the parent
+    # dir name so the slug is unique per source run. (Beaker isolates /results per
+    # task, so it never collided there.)
+    _model_dir_path = Path(source_run.model_dir)
+    _run_name = _model_dir_path.name
+    if _run_name in {"files", "results", "outputs", ""} and _model_dir_path.parent.name:
+        _run_name = f"{_model_dir_path.parent.name}_{_run_name}"
+    source_run_slug = _safe_slug(_run_name)
     checkpoint_component = (
         f"{_safe_slug(source_run.checkpoint_policy)}_{_safe_slug(source_run.checkpoint_label)}"
     )

--- a/code/post_training_analysis/heldout_finetuning.py
+++ b/code/post_training_analysis/heldout_finetuning.py
@@ -1432,8 +1432,19 @@ def _final_metrics_summary(checkpoint_records: Sequence[Mapping[str, Any]]) -> d
         "eval_likelihood": float(final_record["eval_likelihood"]),
     }
     # Propagate the 3-way decomposition (engagement-conditional L/R, engage-vs-
-    # ignore) to heldout/final/* if present. No-op for a 2-way head.
-    for _k in ("eval_likelihood_LR_engaged", "eval_likelihood_engage"):
+    # ignore) plus the ignore-class classification metrics (precision/recall/F1/
+    # PR-AUC at the ~5% ignore base rate) to heldout/final/* if present. No-op
+    # for a 2-way head.
+    _decomp_keys = (
+        "eval_likelihood_LR_engaged",
+        "eval_likelihood_engage",
+        "engage_ignore_base_rate",
+        "engage_ignore_precision",
+        "engage_ignore_recall",
+        "engage_ignore_f1",
+        "engage_ignore_pr_auc",
+    )
+    for _k in _decomp_keys:
         if _k in final_record:
             summary[_k] = float(final_record[_k])
     return summary
@@ -1714,6 +1725,11 @@ def run_heldout_subject_finetuning_from_config(
                             for _k in (
                                 "eval_likelihood_LR_engaged",
                                 "eval_likelihood_engage",
+                                "engage_ignore_base_rate",
+                                "engage_ignore_precision",
+                                "engage_ignore_recall",
+                                "engage_ignore_f1",
+                                "engage_ignore_pr_auc",
                             )
                             if _k in checkpoint_record
                         },

--- a/resume_heldout_beaker.py
+++ b/resume_heldout_beaker.py
@@ -1,0 +1,192 @@
+"""Beaker-side held-out re-scoring for a finished multisubject GRU/disRNN run.
+
+Backfills held-out metrics (e.g. the 3-way ignore-class precision/recall/F1/
+PR-AUC added after some runs were trained) onto an ALREADY-FINISHED run WITHOUT
+re-training and WITHOUT changing the model — the exact-reproduction path.
+
+Difference vs the `DISRNN_RESTORE_FROM_RUN_ID` restore path (`run_hpc`):
+  * restore  -> resumes the TRAINING entrypoint, then runs end-of-train held-out.
+    Even with n_steps capped it evaluates a fresh held-out draw off the restored
+    checkpoint set, so it does NOT reproduce the original held-out numbers.
+  * this tool -> runs the held-out fine-tune ONLY, pointed at the downloaded
+    checkpoint tree, reading every knob (seed, checkpoint_policy, heldout set,
+    finetune n_steps/lr) from the SOURCE run's own config, and re-injects the
+    result into the ORIGINAL W&B run under the `heldout/` namespace. Reproduces
+    the source LR to <1e-7 (proto-validated); the new ignore metrics attach to
+    the identical held-out result the original produced.
+
+This is the Beaker port of the HPC `resume_heldout.py`. The only Beaker-specific
+work is reconstructing `<model_dir>/inputs.yaml` from the W&B run config, because
+the `gru-output-<rid>` artifact ships the `outputs/` tree but NOT inputs.yaml.
+
+Usage (inside a Beaker container that can reach GCS + W&B):
+    python resume_heldout_beaker.py --run-id <wandb_run_id> \
+        [--entity AIND-disRNN] [--project mice_ignore_scaling] \
+        [--work-dir /results/rescore]
+
+Reads WANDB_API_KEY from env (or ~/.netrc).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import wandb
+import yaml
+
+logger = logging.getLogger("resume_heldout_beaker")
+
+
+def _unwrap(d):
+    """Strip W&B config's ``{"value":..., "desc":...}`` wrappers, recursively."""
+    if isinstance(d, dict):
+        if set(d.keys()) <= {"value", "desc"} and "value" in d:
+            return _unwrap(d["value"])
+        return {k: _unwrap(v) for k, v in d.items()}
+    if isinstance(d, list):
+        return [_unwrap(x) for x in d]
+    return d
+
+
+def _reconstruct_inputs_yaml(run, model_dir: Path) -> None:
+    """Rebuild ``<model_dir>/inputs.yaml`` from the source run's config.
+
+    ``resolve_model_run`` requires inputs.yaml (data + model blocks) to rebuild
+    the network and the reserved held-out subject set. The training-output
+    artifact does not include it, but the W&B run config carries the full nested
+    ``data`` and ``model`` blocks. Write exactly those (+ seed) so the resolver
+    sees the same config the original training run used.
+    """
+    cfg = _unwrap(run.config) if isinstance(run.config, dict) else dict(run.config)
+    for key in ("data", "model"):
+        if key not in cfg or not isinstance(cfg[key], dict):
+            raise ValueError(
+                f"Source run config is missing a nested '{key}' block; cannot "
+                f"reconstruct inputs.yaml (keys present: {sorted(cfg)[:20]})."
+            )
+    inputs = {"data": cfg["data"], "model": cfg["model"], "seed": cfg.get("seed")}
+    (model_dir / "inputs.yaml").write_text(yaml.safe_dump(inputs, sort_keys=False))
+    logger.info(
+        "Reconstructed inputs.yaml (model.type=%s, ignore_policy=%s, seed=%s)",
+        cfg["model"].get("type"),
+        cfg["data"].get("ignore_policy"),
+        cfg.get("seed"),
+    )
+
+
+def _build_finetune_config(run, model_dir: Path) -> dict:
+    """Mirror training_runner._run_auto_heldout_finetune's config, sourced from
+    the run's own auto_heldout_finetune block so the held-out draw is identical.
+    """
+    cfg = _unwrap(run.config) if isinstance(run.config, dict) else dict(run.config)
+    auto = cfg["model"].get("training", {}).get("auto_heldout_finetune", {}) or {}
+    return {
+        "source_run": {
+            "model_dir": str(model_dir),
+            # The original auto-held-out used this policy; match it exactly.
+            "checkpoint_policy": str(auto.get("checkpoint_policy", "best_eval")),
+        },
+        # All None -> inherit the reserved held-out set from inputs.yaml.
+        "heldout_subjects": {
+            k: None
+            for k in (
+                "test_subject_ids", "curricula", "min_sessions",
+                "heldout_every_n", "mature_only", "cols_to_retain",
+            )
+        },
+        "heldout_finetuning": {
+            "n_steps": int(auto.get("n_steps", 500)),
+            "lr": float(auto.get("lr", 1e-3)),
+            "checkpoint_every_n_steps": int(auto.get("checkpoint_every_n_steps", 100)),
+            "batch_size": auto.get("batch_size", None),
+            "batch_mode": str(auto.get("batch_mode", "single")),
+            "keep_media_files": bool(auto.get("keep_media_files", True)),
+            "checkpoint_plot_split_examples_every_n": int(
+                auto.get("checkpoint_plot_split_examples_every_n", 100)
+            ),
+            "checkpoint_save_output_df_every_n": int(
+                auto.get("checkpoint_save_output_df_every_n", 0)
+            ),
+            "train_example_sessions_per_subject": int(
+                auto.get("train_example_sessions_per_subject", 1)
+            ),
+            "eval_example_sessions_per_subject": int(
+                auto.get("eval_example_sessions_per_subject", 1)
+            ),
+            "example_max_subjects": int(auto.get("example_max_subjects", 1)),
+        },
+        "output": {
+            "output_root": str(model_dir.parent / "heldout_rescore"),
+            "run_name_suffix": None,
+        },
+        "seed": cfg.get("seed"),
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--run-id", required=True, help="Source W&B run id to re-score.")
+    p.add_argument("--entity", default="AIND-disRNN")
+    p.add_argument("--project", default="mice_ignore_scaling")
+    p.add_argument("--work-dir", default="/results/rescore")
+    args = p.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO, format="[%(asctime)s][%(name)s][%(levelname)s] %(message)s"
+    )
+    # The wrapper package lives under code/; make its modules importable.
+    repo_code = Path(__file__).resolve().parent / "code"
+    sys.path.insert(0, str(repo_code))
+    from post_training_analysis import run_heldout_subject_finetuning_from_config
+
+    work = Path(args.work_dir).expanduser()
+    model_dir = work / args.run_id
+    outputs_dir = model_dir / "outputs"
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+
+    api = wandb.Api()
+
+    # 1) Download the training-output artifact into <model_dir>/outputs so the
+    #    checkpoints/step_<N>/ tree lands where resolve_model_run looks.
+    mtype = "gru"  # ignore-scaling grid is all GRU; disRNN would be "disrnn"
+    artifact_ref = f"{args.entity}/{args.project}/{mtype}-output-{args.run_id}:latest"
+    logger.info("Downloading %s -> %s", artifact_ref, outputs_dir)
+    api.artifact(artifact_ref, type="training-output").download(root=str(outputs_dir))
+    steps = sorted((outputs_dir / "checkpoints").glob("step_*"))
+    if not steps:
+        raise RuntimeError(f"No checkpoints/step_* under {outputs_dir} after download.")
+    logger.info("Downloaded %d checkpoint(s); latest=%s", len(steps), steps[-1].name)
+
+    # 2) Reconstruct inputs.yaml from the run config.
+    src_run = api.run(f"{args.entity}/{args.project}/{args.run_id}")
+    _reconstruct_inputs_yaml(src_run, model_dir)
+
+    # 3) Resume the ORIGINAL W&B run and inject held-out-only metrics into it.
+    finetune_config = _build_finetune_config(src_run, model_dir)
+    wandb_run = wandb.init(
+        entity=args.entity, project=args.project, id=args.run_id, resume="must"
+    )
+    step_offset = int(getattr(wandb_run, "step", 0) or 0) + 1
+    logger.info(
+        "Re-scoring held-out for run %s (checkpoint_policy=%s n_steps=%s)",
+        args.run_id,
+        finetune_config["source_run"]["checkpoint_policy"],
+        finetune_config["heldout_finetuning"]["n_steps"],
+    )
+    result = run_heldout_subject_finetuning_from_config(
+        finetune_config,
+        wandb_run=wandb_run,
+        wandb_key_prefix="heldout",
+        wandb_step_offset=step_offset,
+    )
+    wandb_run.finish()
+    logger.info("Held-out re-score finished. output_dir=%s", result.get("output_dir"))
+    print(json.dumps({"run_id": args.run_id, "output_dir": result.get("output_dir")}))
+
+
+if __name__ == "__main__":
+    main()

--- a/resume_heldout_beaker.py
+++ b/resume_heldout_beaker.py
@@ -29,16 +29,43 @@ Reads WANDB_API_KEY from env (or ~/.netrc).
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import logging
 import os
 import sys
+import urllib.request
 from pathlib import Path
 
 import wandb
 import yaml
 
 logger = logging.getLogger("resume_heldout_beaker")
+
+
+def _fetch_run_config(entity: str, project: str, run_id: str) -> dict:
+    """Fetch a run's config via the W&B GraphQL endpoint directly.
+
+    Avoids ``wandb.Api().run()`` — that auto-loads the run's Sweep, and the
+    Sweep.get() query is broken in the container's wandb build (raises
+    'Object of type Api is not JSON serializable'). A plain GraphQL POST for the
+    config field sidesteps the whole run/sweep object graph.
+    """
+    key = os.environ["WANDB_API_KEY"]
+    q = (
+        'query{project(name:"%s",entityName:"%s"){run(name:"%s"){config}}}'
+        % (project, entity, run_id)
+    )
+    body = json.dumps({"query": q}).encode()
+    auth = base64.b64encode(f"api:{key}".encode()).decode()
+    req = urllib.request.Request(
+        "https://api.wandb.ai/graphql",
+        data=body,
+        headers={"Content-Type": "application/json", "Authorization": "Basic " + auth},
+    )
+    resp = json.load(urllib.request.urlopen(req))
+    raw = resp["data"]["project"]["run"]["config"]
+    return json.loads(raw) if isinstance(raw, str) else raw
 
 
 def _unwrap(d):
@@ -52,7 +79,7 @@ def _unwrap(d):
     return d
 
 
-def _reconstruct_inputs_yaml(run, model_dir: Path) -> None:
+def _reconstruct_inputs_yaml(cfg: dict, model_dir: Path) -> None:
     """Rebuild ``<model_dir>/inputs.yaml`` from the source run's config.
 
     ``resolve_model_run`` requires inputs.yaml (data + model blocks) to rebuild
@@ -61,7 +88,7 @@ def _reconstruct_inputs_yaml(run, model_dir: Path) -> None:
     ``data`` and ``model`` blocks. Write exactly those (+ seed) so the resolver
     sees the same config the original training run used.
     """
-    cfg = _unwrap(run.config) if isinstance(run.config, dict) else dict(run.config)
+    cfg = _unwrap(cfg)
     for key in ("data", "model"):
         if key not in cfg or not isinstance(cfg[key], dict):
             raise ValueError(
@@ -78,11 +105,11 @@ def _reconstruct_inputs_yaml(run, model_dir: Path) -> None:
     )
 
 
-def _build_finetune_config(run, model_dir: Path) -> dict:
+def _build_finetune_config(cfg: dict, model_dir: Path) -> dict:
     """Mirror training_runner._run_auto_heldout_finetune's config, sourced from
     the run's own auto_heldout_finetune block so the held-out draw is identical.
     """
-    cfg = _unwrap(run.config) if isinstance(run.config, dict) else dict(run.config)
+    cfg = _unwrap(cfg)
     auto = cfg["model"].get("training", {}).get("auto_heldout_finetune", {}) or {}
     return {
         "source_run": {
@@ -161,12 +188,12 @@ def main() -> None:
         raise RuntimeError(f"No checkpoints/step_* under {outputs_dir} after download.")
     logger.info("Downloaded %d checkpoint(s); latest=%s", len(steps), steps[-1].name)
 
-    # 2) Reconstruct inputs.yaml from the run config.
-    src_run = api.run(f"{args.entity}/{args.project}/{args.run_id}")
-    _reconstruct_inputs_yaml(src_run, model_dir)
+    # 2) Reconstruct inputs.yaml from the run config (via GraphQL, not api.run()).
+    src_cfg = _fetch_run_config(args.entity, args.project, args.run_id)
+    _reconstruct_inputs_yaml(src_cfg, model_dir)
 
     # 3) Resume the ORIGINAL W&B run and inject held-out-only metrics into it.
-    finetune_config = _build_finetune_config(src_run, model_dir)
+    finetune_config = _build_finetune_config(src_cfg, model_dir)
     wandb_run = wandb.init(
         entity=args.entity, project=args.project, id=args.run_id, resume="must"
     )

--- a/resume_heldout_beaker.py
+++ b/resume_heldout_beaker.py
@@ -188,6 +188,29 @@ def main() -> None:
         raise RuntimeError(f"No checkpoints/step_* under {outputs_dir} after download.")
     logger.info("Downloaded %d checkpoint(s); latest=%s", len(steps), steps[-1].name)
 
+    # 1b) Normalize checkpoints/index.json params_path entries to RELATIVE form.
+    #     The index records each params_path as the ORIGINAL absolute HPC path
+    #     (/allen/.../files/outputs/checkpoints/step_N/params.json). resolve_model_run's
+    #     _resolve_artifact_path remaps such a path by splitting on the FIRST "/outputs/",
+    #     but the HPC path contains "/outputs/" twice (/han.hou/outputs/disrnn AND
+    #     /files/outputs/), so the remap points at a nonexistent path and best_eval
+    #     SILENTLY falls back to `final` (step_90000) instead of the true best checkpoint.
+    #     Rewriting each params_path to "outputs/checkpoints/step_N/params.json" makes the
+    #     resolver take its unambiguous startswith("outputs/") branch -> model_dir/<that>.
+    index_path = outputs_dir / "checkpoints" / "index.json"
+    if index_path.exists():
+        index = json.loads(index_path.read_text())
+        rewritten = 0
+        for rec in index.get("checkpoints", []) or []:
+            step = rec.get("step")
+            if step is not None:
+                rec["params_path"] = f"outputs/checkpoints/step_{step}/params.json"
+                rewritten += 1
+        index_path.write_text(json.dumps(index))
+        logger.info("Normalized %d params_path entries in index.json to relative form.", rewritten)
+    else:
+        logger.warning("No checkpoints/index.json found; best_eval selection may fall back to final.")
+
     # 2) Reconstruct inputs.yaml from the run config (via GraphQL, not api.run()).
     src_cfg = _fetch_run_config(args.entity, args.project, args.run_id)
     _reconstruct_inputs_yaml(src_cfg, model_dir)


### PR DESCRIPTION
## Summary

Held-out evaluation support for the **3-way (L/R/ignore) GRU head** used by the
`ignore-trials-scaling` study (dispatcher study branch `feat/ignore-trials-scaling`).
Adds the metrics that study reports, plus a Beaker-side exact re-score tool.

## What's in it (10 commits)

**Metrics / decomposition**
- `acccb3d` engagement metrics + P(ignore) state-space panel for the 3-way head
- `87bf19b` held-out 3-way conditional L/R + engage decomposition (L/R-engaged, engage)
- `cbbc2cf` log P(ignore) engagement panel to W&B (checkpoint + held-out paths)
- `0a386ba` ignore-class precision / recall / F1 / PR-AUC in the 3-way decomposition
- `4530d04` propagate `engage_ignore_*` metrics to run summary + W&B

**Held-out plumbing / fixes**
- `67e324b` namespace held-out `output_dir` by source run id (fixes cross-cell collision)
- `b38ad26` reserve suptitle headroom so session id doesn't overlap panel titles

**Exact held-out re-score on Beaker** (the correctness fix — see below)
- `c757463` Beaker port of `resume_heldout` for exact held-out re-scoring
- `82e6539` fetch run config via GraphQL (container's `wandb.Api().run()` raises on sweep auto-load)
- `0a9141b` normalize `index.json` `params_path` so `best_eval` selects the right checkpoint

## Why the re-score tool matters

12 of the study's 48 grid cells had their ignore metrics originally backfilled via a
restore path that **resumed base training** (early-stop patience reset), over-training
the model and producing wrong held-out metrics. `resume_heldout_beaker.py` re-runs the
held-out finetune-and-eval **only** on the native checkpoint, reproducing the native
L/R-engaged value to <1e-6. Full audit in the dispatcher study's
`analysis/provenance/backfill_history.md`.

## Metric convention

The raw 3-way normalized likelihood (chance 1/3) is **not** comparable to the 2-way L/R
likelihood (chance 1/2). Downstream analysis scores the conditional L/R likelihood on
engaged trials (`eval_likelihood_LR_engaged`) as the like-for-like comparator, and the
ignore-class detection metrics separately. Key contract documented in the study's
`analysis/wandb_keys.py`.

## Merge order

Merge this **before** the dispatcher ignore-scaling PR — the dispatcher study pins this
wrapper commit (`0a9141b`) in its `environment.lock`.
