### PR TITLE
docs: point agents at the dispatcher skills pack; fix stale image ref

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "aind-behavior-foundation-model": {
+      "source": {
+        "source": "github",
+        "repo": "AllenNeuralDynamics/aind-disrnn-dispatcher"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "aind-behavior-foundation-model-skills@aind-behavior-foundation-model": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,9 @@ dmypy.json
 !.vscode/*.code-snippets
 .vscode
 
-.claude/
+# Claude Code: track only the shared project settings (skills-pack enablement)
+.claude/*
+!.claude/settings.json
 
 # Other editable repos
 src

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,3 +100,17 @@ Rules:
 - Use `<scope>` for the affected area when helpful (e.g. `feat(launcher): ...`, `docs(readme): ...`).
 - Mark breaking changes with `!` after the type/scope (e.g. `feat(api)!: ...`) and a `BREAKING CHANGE:` footer.
 - Body explains the motivation and any non-obvious consequences; don't restate the diff.
+
+## 7. Project Skills & Living Docs
+
+- The **Agent Skills pack** for this two-repo project lives in the dispatcher:
+  `aind-disrnn-dispatcher/aind-behavior-foundation-model-skills/`. It is the
+  canonical home for cross-cutting operational knowledge — Beaker/HPC launching,
+  study conventions, post-hoc reporting, and this repo's runtime distilled in the
+  `wrapper-runtime` skill. It is auto-enabled here via the checked-in
+  `.claude/settings.json` (Claude Code plugin marketplace).
+- This repo's **living documents stay canonical** for code-coupled reference:
+  `code/TRAINING.md` (read §1.5 "Run lifecycle & key switches" first) and
+  `code/POST_TRAINING_ANALYSIS.md`. When you add or change a feature, update the
+  relevant guide + its Changelog — the skills defer to these files.
+- Never squash-merge a PR (`gh pr merge <n> --merge`) — preserve per-commit history.

--- a/beaker/README.md
+++ b/beaker/README.md
@@ -191,7 +191,7 @@ eval-throttling (item 10) were both tested and gave nothing. For *scale*, use
 |---|---|
 | Workspace | `ai1/aind-dynamic-foraging-foundation-model` |
 | Cluster (L40s) | `ai1/octo-hub-aws-l40s` |
-| Image ref | `han-hou/disrnn-wrapper` (from `beaker image get disrnn-wrapper`) |
+| Image ref | `han-hou/disrnn-wrapper-pck-integration-20260630` — the original `han-hou/disrnn-wrapper` **no longer exists** (`ImageNotFound`). Authoritative list: the dispatcher's `code/beaker/README.md` "Available images" table, or `beaker workspace images ai1/aind-dynamic-foraging-foundation-model` |
 | W&B secret | `han-wandb-api-key` (a Beaker secret holding `WANDB_API_KEY`) |
 
 ---


### PR DESCRIPTION
Companion to dispatcher PR AllenNeuralDynamics/aind-disrnn-dispatcher#48 (skills as single source of truth).

- **AGENTS.md §7 (new):** points agents at the Agent Skills pack in the dispatcher (`aind-behavior-foundation-model-skills/`) for cross-repo operational knowledge, and states that this repo's living docs (`code/TRAINING.md`, `code/POST_TRAINING_ANALYSIS.md`) remain canonical for code-coupled reference. Also adds the no-squash-merge rule the dispatcher AGENTS.md already had.
- **`.claude/settings.json` (new):** auto-enables the skills pack for Claude Code sessions in this repo via the dispatcher-hosted plugin marketplace — wrapper sessions get the same `wrapper-runtime` / `beaker-launch` / etc. skills. `.gitignore` narrowed from `.claude/` to `.claude/*` + `!.claude/settings.json` so only the shared settings file is tracked.
- **`beaker/README.md` stale fact:** the "Resolved settings" table still listed `han-hou/disrnn-wrapper`, which no longer exists (`ImageNotFound`); now points at `han-hou/disrnn-wrapper-pck-integration-20260630` and the dispatcher's "Available images" table as the authoritative list. Migration-log mentions of the old name are left as history.

**Merge, do not squash.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)