### PR TITLE
fix(synthetic): clamp LossCounting/CTT session params to model bounds

### DIFF
--- a/code/data_loaders/hierarchical_synthetic.py
+++ b/code/data_loaders/hierarchical_synthetic.py
@@ -91,9 +91,18 @@ _TASK_LOOKUP = {
     "random_walk": RandomWalkTask,
 }
 
-# Conservative clamp bounds for ForagerQLearning params (mirrors the pydantic
-# field constraints in aind_dynamic_foraging_models: learn_rate in [0,1],
-# rates in [0,1], softmax_inverse_temperature >= 0, biasL fit-bounds +/-5).
+# Conservative clamp bounds mirroring the pydantic field constraints in
+# aind_dynamic_foraging_models, applied after drift+noise so a rare tail excursion
+# cannot produce an out-of-range value that the model rejects.
+#   ForagerQLearning:       learn_rate/rates in [0,1], softmax_inv_temp >= 0,
+#                           biasL fit-bounds +/-5.
+#   ForagerCompareThreshold: threshold >= 0.
+#   ForagerLossCounting:    loss_count_threshold_{mean,std} >= 0 (a count / its std).
+# Stage-4b mixes families per session, so the LossCounting/CTT params below MUST be
+# clamped too: at high mixture concentration many more LossCounting sessions are drawn,
+# and drift+session_noise can push loss_count_threshold_mean slightly below 0
+# (pydantic ge=0 -> ValidationError, killing the whole generation job). Upper bound is
+# left open (inf) where the model has none, so drift extrapolation is not capped.
 _PARAM_CLAMP: dict[str, tuple[float, float]] = {
     "learn_rate": (0.0, 1.0),
     "learn_rate_rew": (0.0, 1.0),
@@ -104,6 +113,9 @@ _PARAM_CLAMP: dict[str, tuple[float, float]] = {
     "softmax_inverse_temperature": (0.0, 100.0),
     "biasL": (-5.0, 5.0),
     "epsilon": (0.0, 1.0),
+    "threshold": (0.0, np.inf),
+    "loss_count_threshold_mean": (0.0, np.inf),
+    "loss_count_threshold_std": (0.0, np.inf),
 }
 
 

--- a/code/tests/test_hierarchical_synthetic.py
+++ b/code/tests/test_hierarchical_synthetic.py
@@ -53,6 +53,13 @@ def test_pure_logic_clamp_and_drift():
     assert hs._clamp("learn_rate", -0.3) == 0.0
     assert hs._clamp("biasL", 9.0) == 5.0
     assert hs._clamp("softmax_inverse_temperature", -1.0) == 0.0
+    # Stage-4b mixture-family params: LossCounting / CompareThreshold floors at 0
+    # (drift+noise can push these slightly negative; pydantic ge=0 would reject them).
+    assert hs._clamp("loss_count_threshold_mean", -0.0101) == 0.0
+    assert hs._clamp("loss_count_threshold_std", -0.5) == 0.0
+    assert hs._clamp("threshold", -0.2) == 0.0
+    # upper bound is open (no artificial cap on drift extrapolation)
+    assert hs._clamp("loss_count_threshold_mean", 7.5) == 7.5
     # linear drift
     assert hs._apply_drift("learn_rate", 0.2, {"mode": "linear", "delta": 0.4}, 0.0) == 0.2
     assert abs(hs._apply_drift("learn_rate", 0.2, {"mode": "linear", "delta": 0.4}, 1.0) - 0.6) < 1e-9


### PR DESCRIPTION
## Problem
Stage-4b synthetic generation crashes (whole job dies) when a mixture-family session's `loss_count_threshold_mean` drifts+noises slightly below 0:

```
pydantic ValidationError: loss_count_threshold_mean
Input should be >= 0  [input_value = -0.010070857507883169]
```

`_session_params` already clamps via `_clamp`, but `_PARAM_CLAMP` only listed **ForagerQLearning** params — the LossCounting/CompareThreshold family params fell through to `(-inf, inf)` and were never clamped.

## Why it surfaced now
Exposed by `studies/04-gru-vs-disrnn-embedding-recovery/variants/gru-stage4b-concentration` (a Dirichlet-concentration sweep). At high mixture concentration, subjects draw **many more LossCounting sessions**, so the rare sub-zero tail excursion of `loss_count_threshold_mean` actually gets hit. Almost certainly also the cause of `gru-stage4b`'s previously-unexplained one-cell crash at α=0.5.

## Fix
Add floor-at-0 bounds for `loss_count_threshold_mean`, `loss_count_threshold_std`, and CompareThreshold `threshold` (all non-negative by definition). Upper bound left open (`inf`) so **drift extrapolation is not capped** (Stage-2b's sensitive split relies on drift moving params beyond the draw range). Extends `test_pure_logic_clamp_and_drift` with the new params including the exact crash value.

## Verification
- Clamp logic verified standalone against the exact crash value (`-0.0100708 → 0.0`; drift value `7.5` not capped; existing QL clamps intact).
- Full pytest not run here (the training stack isn't installable in the launch sandbox; §5 keeps heavy work off the login node) — the added assertions are pure-logic and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WReHDhDFAfXXDN7Jxh8Grm