### PR TITLE
feat(beaker): refresh foraging models at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ that launched it. This is achieved with three complementary mechanisms:
    - `wandb.init(config=...)` records the `data`, `model`, and `meta` blocks
      from the resolved Hydra config, so they are filterable and groupable in the
      W&B UI.
-   - Beaker runs also stamp `wrapper_commit`, `dispatcher_commit`, and
-     `foraging_models_commit` after refreshing all three repositories.
+   - Beaker runs also stamp `wrapper_commit`, `dispatcher_commit`,
+     `foraging_models_commit`, and `disentangled_rnns_commit` after refreshing
+     all four repositories.
 
 3. Dispatcher lineage injection for HPC sweeps.
    - At sweep creation time, `aind-disrnn-dispatcher/code/launch_hpc.py`

--- a/README.md
+++ b/README.md
@@ -79,9 +79,8 @@ that launched it. This is achieved with three complementary mechanisms:
    - `wandb.init(config=...)` records the `data`, `model`, and `meta` blocks
      from the resolved Hydra config, so they are filterable and groupable in the
      W&B UI.
-   - Beaker runs also stamp `wrapper_commit`, `dispatcher_commit`,
-     `foraging_models_commit`, and `disentangled_rnns_commit` after refreshing
-     all four repositories.
+   - Beaker runs also stamp `wrapper_commit`, `dispatcher_commit`, and
+     `foraging_models_commit` after refreshing all three repositories.
 
 3. Dispatcher lineage injection for HPC sweeps.
    - At sweep creation time, `aind-disrnn-dispatcher/code/launch_hpc.py`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ that launched it. This is achieved with three complementary mechanisms:
    - `wandb.init(config=...)` records the `data`, `model`, and `meta` blocks
      from the resolved Hydra config, so they are filterable and groupable in the
      W&B UI.
+   - Beaker runs also stamp `wrapper_commit`, `dispatcher_commit`, and
+     `foraging_models_commit` after refreshing all three repositories.
 
 3. Dispatcher lineage injection for HPC sweeps.
    - At sweep creation time, `aind-disrnn-dispatcher/code/launch_hpc.py`

--- a/beaker/BUILD_LOG.md
+++ b/beaker/BUILD_LOG.md
@@ -13,9 +13,28 @@ job executes.
 
 ## Live images
 
-### `han-hou/disrnn-wrapper-pck-integration-20260630`
+### `han-hou/disrnn-wrapper-main-20260712`
 
 - **Status:** current; use for new studies
+- **Beaker image ID:** `01KXCF2EASQ8NV463684PZJ0ZP`
+- **Created:** 2026-07-12 17:47 PT
+- **Committed:** 2026-07-12 17:50 PT
+- **Size:** 6,703,239,968 bytes (6.70 GB)
+- **Build host:** Mac, `linux/amd64`
+- **Baked wrapper ref:** `a4792b042ec61193f37c2be58c44f04479cb2e9b`
+- **Baked dispatcher ref:** `7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23`
+- **Baked foraging-models ref:** `b44b0912de8d5307debe9b3b1c570cfc6dad816e`
+- **Baked disentangled-rnns ref:** `a9b9978831cb22d37e2a75c15805c621dfe00b1f`
+- **Reason:** default runtime refs now target `main`; foraging-models is refreshed
+  from GitHub at job startup and records its resolved commit, while
+  disentangled-rnns remains image-baked
+- **Smoke test:** [experiment `01KXCGK6MM6QV3AND8C7ZC1TCX`](https://beaker.org/ex/01KXCGK6MM6QV3AND8C7ZC1TCX),
+  exit code 0 on one g6e GPU; runtime refs, JAX CUDA, imports, Hydra composition,
+  and `SMOKE OK` verified
+
+### `han-hou/disrnn-wrapper-pck-integration-20260630`
+
+- **Status:** deprecated; retained for older runs
 - **Beaker image ID:** `01KWDGGQ4A9BTDXDHCGWXBWG05`
 - **Created:** 2026-06-30 17:16 PT
 - **Committed:** 2026-06-30 17:21 PT

--- a/beaker/BUILD_LOG.md
+++ b/beaker/BUILD_LOG.md
@@ -6,7 +6,8 @@ Registry history for the disRNN wrapper images in
 The timestamps, Beaker IDs, and sizes below were reconstructed from the live
 Beaker image records on 2026-07-12. Historical build refs were not stored by
 Beaker and are marked as unknown rather than inferred from image names. Runtime
-jobs still refresh both repositories through `WRAPPER_REF` and `DISPATCHER_REF`;
+jobs refresh all three repositories through `WRAPPER_REF`, `DISPATCHER_REF`, and
+`FORAGING_MODELS_REF`;
 the baked refs describe the dependency environment, not necessarily the code a
 job executes.
 
@@ -22,6 +23,7 @@ job executes.
 - **Build host:** Mac, `linux/amd64`
 - **Baked wrapper ref:** unknown (not recorded at build time)
 - **Baked dispatcher ref:** unknown (not recorded at build time)
+- **Baked foraging-models ref:** PyPI `0.13.0` (no dynamic checkout)
 - **Reason:** refresh dependencies for the snapshot-backed mice data path;
   includes `aind-dynamic-foraging-database` support for
   `select_sessions(snapshot=...)`
@@ -36,6 +38,7 @@ job executes.
 - **Build host:** Mac, `linux/amd64`
 - **Baked wrapper ref:** unknown (not recorded at build time)
 - **Baked dispatcher ref:** unknown (not recorded at build time)
+- **Baked foraging-models ref:** PyPI `0.13.0` (no dynamic checkout)
 - **Reason:** AI Hub integration image before the snapshot database dependency
   update; incompatible with loaders that call `select_sessions(snapshot=...)`
 
@@ -57,7 +60,7 @@ After `build_and_push.sh` succeeds, add an entry above with:
 - registry-created and committed timestamps in Seattle time
 - image size
 - build host and target platform
-- exact baked wrapper and dispatcher refs
+- exact baked wrapper, dispatcher, and foraging-models refs
 - dependency or environment change that required the rebuild
 - smoke-test experiment ID and result, when available
 
@@ -67,5 +70,6 @@ Read registry metadata with:
 beaker image get <image-name> --format json
 ```
 
-Use full commit SHAs for `--wrapper-ref` and `--dispatcher-ref` when building a
-release image so the baked dependency environment can be reproduced.
+Use full commit SHAs for `--wrapper-ref`, `--dispatcher-ref`, and
+`--foraging-models-ref` when building a release image so the baked dependency
+environment can be reproduced.

--- a/beaker/BUILD_LOG.md
+++ b/beaker/BUILD_LOG.md
@@ -6,8 +6,8 @@ Registry history for the disRNN wrapper images in
 The timestamps, Beaker IDs, and sizes below were reconstructed from the live
 Beaker image records on 2026-07-12. Historical build refs were not stored by
 Beaker and are marked as unknown rather than inferred from image names. Runtime
-jobs refresh all four repositories through `WRAPPER_REF`, `DISPATCHER_REF`,
-`FORAGING_MODELS_REF`, and `DISENTANGLED_RNNS_REF`;
+jobs refresh all three repositories through `WRAPPER_REF`, `DISPATCHER_REF`, and
+`FORAGING_MODELS_REF`;
 the baked refs describe the dependency environment, not necessarily the code a
 job executes.
 
@@ -24,8 +24,6 @@ job executes.
 - **Baked wrapper ref:** unknown (not recorded at build time)
 - **Baked dispatcher ref:** unknown (not recorded at build time)
 - **Baked foraging-models ref:** PyPI `0.13.0` (no dynamic checkout)
-- **Baked disentangled-rnns ref:** `a9b9978831cb22d37e2a75c15805c621dfe00b1f`
-  (installed directly from GitHub; no dynamic checkout)
 - **Reason:** refresh dependencies for the snapshot-backed mice data path;
   includes `aind-dynamic-foraging-database` support for
   `select_sessions(snapshot=...)`
@@ -41,8 +39,6 @@ job executes.
 - **Baked wrapper ref:** unknown (not recorded at build time)
 - **Baked dispatcher ref:** unknown (not recorded at build time)
 - **Baked foraging-models ref:** PyPI `0.13.0` (no dynamic checkout)
-- **Baked disentangled-rnns ref:** `a9b9978831cb22d37e2a75c15805c621dfe00b1f`
-  (installed directly from GitHub; no dynamic checkout)
 - **Reason:** AI Hub integration image before the snapshot database dependency
   update; incompatible with loaders that call `select_sessions(snapshot=...)`
 
@@ -64,7 +60,7 @@ After `build_and_push.sh` succeeds, add an entry above with:
 - registry-created and committed timestamps in Seattle time
 - image size
 - build host and target platform
-- exact baked wrapper, dispatcher, foraging-models, and disentangled-rnns refs
+- exact baked wrapper, dispatcher, and foraging-models refs
 - dependency or environment change that required the rebuild
 - smoke-test experiment ID and result, when available
 
@@ -75,5 +71,5 @@ beaker image get <image-name> --format json
 ```
 
 Use full commit SHAs for `--wrapper-ref`, `--dispatcher-ref`, and
-`--foraging-models-ref`, and `--disentangled-rnns-ref` when building a release
-image so the baked dependency environment can be reproduced.
+`--foraging-models-ref` when building a release image so the baked dependency
+environment can be reproduced.

--- a/beaker/BUILD_LOG.md
+++ b/beaker/BUILD_LOG.md
@@ -1,0 +1,71 @@
+# Beaker image build log
+
+Registry history for the disRNN wrapper images in
+`ai1/aind-dynamic-foraging-foundation-model`.
+
+The timestamps, Beaker IDs, and sizes below were reconstructed from the live
+Beaker image records on 2026-07-12. Historical build refs were not stored by
+Beaker and are marked as unknown rather than inferred from image names. Runtime
+jobs still refresh both repositories through `WRAPPER_REF` and `DISPATCHER_REF`;
+the baked refs describe the dependency environment, not necessarily the code a
+job executes.
+
+## Live images
+
+### `han-hou/disrnn-wrapper-pck-integration-20260630`
+
+- **Status:** current; use for new studies
+- **Beaker image ID:** `01KWDGGQ4A9BTDXDHCGWXBWG05`
+- **Created:** 2026-06-30 17:16 PT
+- **Committed:** 2026-06-30 17:21 PT
+- **Size:** 6,525,783,072 bytes (6.53 GB)
+- **Build host:** Mac, `linux/amd64`
+- **Baked wrapper ref:** unknown (not recorded at build time)
+- **Baked dispatcher ref:** unknown (not recorded at build time)
+- **Reason:** refresh dependencies for the snapshot-backed mice data path;
+  includes `aind-dynamic-foraging-database` support for
+  `select_sessions(snapshot=...)`
+
+### `han-hou/disrnn-wrapper-pck-integration`
+
+- **Status:** deprecated; retained for older runs
+- **Beaker image ID:** `01KVEHPZ76A85CHWEWBQ43R6EY`
+- **Created:** 2026-06-18 16:40 PT
+- **Committed:** 2026-06-18 16:43 PT
+- **Size:** 6,527,125,878 bytes (6.53 GB)
+- **Build host:** Mac, `linux/amd64`
+- **Baked wrapper ref:** unknown (not recorded at build time)
+- **Baked dispatcher ref:** unknown (not recorded at build time)
+- **Reason:** AI Hub integration image before the snapshot database dependency
+  update; incompatible with loaders that call `select_sessions(snapshot=...)`
+
+## Retired images
+
+### `han-hou/disrnn-wrapper`
+
+- **Status:** deleted from Beaker
+- **Beaker image ID:** unknown
+- **Created / committed:** unknown
+- **Size:** unknown
+- **Reason:** original AI Hub MVP image; superseded by the integration images
+
+## Recording a new build
+
+After `build_and_push.sh` succeeds, add an entry above with:
+
+- full Beaker image name and image ID
+- registry-created and committed timestamps in Seattle time
+- image size
+- build host and target platform
+- exact baked wrapper and dispatcher refs
+- dependency or environment change that required the rebuild
+- smoke-test experiment ID and result, when available
+
+Read registry metadata with:
+
+```bash
+beaker image get <image-name> --format json
+```
+
+Use full commit SHAs for `--wrapper-ref` and `--dispatcher-ref` when building a
+release image so the baked dependency environment can be reproduced.

--- a/beaker/BUILD_LOG.md
+++ b/beaker/BUILD_LOG.md
@@ -6,8 +6,8 @@ Registry history for the disRNN wrapper images in
 The timestamps, Beaker IDs, and sizes below were reconstructed from the live
 Beaker image records on 2026-07-12. Historical build refs were not stored by
 Beaker and are marked as unknown rather than inferred from image names. Runtime
-jobs refresh all three repositories through `WRAPPER_REF`, `DISPATCHER_REF`, and
-`FORAGING_MODELS_REF`;
+jobs refresh all four repositories through `WRAPPER_REF`, `DISPATCHER_REF`,
+`FORAGING_MODELS_REF`, and `DISENTANGLED_RNNS_REF`;
 the baked refs describe the dependency environment, not necessarily the code a
 job executes.
 
@@ -24,6 +24,8 @@ job executes.
 - **Baked wrapper ref:** unknown (not recorded at build time)
 - **Baked dispatcher ref:** unknown (not recorded at build time)
 - **Baked foraging-models ref:** PyPI `0.13.0` (no dynamic checkout)
+- **Baked disentangled-rnns ref:** `a9b9978831cb22d37e2a75c15805c621dfe00b1f`
+  (installed directly from GitHub; no dynamic checkout)
 - **Reason:** refresh dependencies for the snapshot-backed mice data path;
   includes `aind-dynamic-foraging-database` support for
   `select_sessions(snapshot=...)`
@@ -39,6 +41,8 @@ job executes.
 - **Baked wrapper ref:** unknown (not recorded at build time)
 - **Baked dispatcher ref:** unknown (not recorded at build time)
 - **Baked foraging-models ref:** PyPI `0.13.0` (no dynamic checkout)
+- **Baked disentangled-rnns ref:** `a9b9978831cb22d37e2a75c15805c621dfe00b1f`
+  (installed directly from GitHub; no dynamic checkout)
 - **Reason:** AI Hub integration image before the snapshot database dependency
   update; incompatible with loaders that call `select_sessions(snapshot=...)`
 
@@ -60,7 +64,7 @@ After `build_and_push.sh` succeeds, add an entry above with:
 - registry-created and committed timestamps in Seattle time
 - image size
 - build host and target platform
-- exact baked wrapper, dispatcher, and foraging-models refs
+- exact baked wrapper, dispatcher, foraging-models, and disentangled-rnns refs
 - dependency or environment change that required the rebuild
 - smoke-test experiment ID and result, when available
 
@@ -71,5 +75,5 @@ beaker image get <image-name> --format json
 ```
 
 Use full commit SHAs for `--wrapper-ref`, `--dispatcher-ref`, and
-`--foraging-models-ref` when building a release image so the baked dependency
-environment can be reproduced.
+`--foraging-models-ref`, and `--disentangled-rnns-ref` when building a release
+image so the baked dependency environment can be reproduced.

--- a/beaker/Dockerfile
+++ b/beaker/Dockerfile
@@ -1,6 +1,6 @@
 # Beaker (AI Hub) image for the disRNN wrapper — GPU.
 #
-# Clones the four runtime source repos from GitHub.
+# Clones the dispatcher, wrapper, and dynamic-foraging-models repos from GitHub.
 # The dispatcher and wrapper use the sibling layout that run_hpc.py expects:
 #   /workspace/aind-disrnn-wrapper/code/run_hpc.py reads its Hydra configs from
 #   ../../aind-disrnn-dispatcher/code/config  ->  /workspace/aind-disrnn-dispatcher/...
@@ -35,14 +35,13 @@ ARG GH_ORG=https://github.com/AllenNeuralDynamics
 ARG DISPATCHER_REF=main
 ARG WRAPPER_REF=main
 ARG FORAGING_MODELS_REF=main
-ARG DISENTANGLED_RNNS_REF=main
 
-# Clone all four repos and install the wrapper + GPU JAX. All repos
+# Clone all three repos and install the wrapper + GPU JAX. All repos
 # and the wrapper's git deps (disentangled-rnns, aind-disrnn-utils) are public,
 # so no credentials are needed.
 #
 # The baked code is only a STARTING POINT: at job startup beaker/entrypoint.sh
-# re-pulls all four repos to the requested refs (default main), so the image
+# re-pulls all three repos to the requested refs (default main), so the image
 # rarely needs rebuilding — only when DEPENDENCIES change. The build-time clone exists
 # mainly to (a) install deps from pyproject and (b) seed the repos so entrypoint.sh
 # can `git fetch` them. See beaker/entrypoint.sh and the README.
@@ -65,13 +64,10 @@ RUN clone_ref() { \
       /workspace/aind-disrnn-dispatcher "$DISPATCHER_REF" && \
     clone_ref "$GH_ORG/aind-dynamic-foraging-models.git" \
       /workspace/aind-dynamic-foraging-models "$FORAGING_MODELS_REF" && \
-    clone_ref "$GH_ORG/aind-disentangled-rnns.git" \
-      /workspace/aind-disentangled-rnns "$DISENTANGLED_RNNS_REF" && \
     clone_ref "$GH_ORG/aind-disrnn-wrapper.git" \
       /workspace/aind-disrnn-wrapper "$WRAPPER_REF" && \
     pip install --no-cache-dir -e "/workspace/aind-disrnn-wrapper[gpu]" && \
-    pip install --no-cache-dir -e /workspace/aind-dynamic-foraging-models && \
-    pip install --no-cache-dir -e /workspace/aind-disentangled-rnns
+    pip install --no-cache-dir -e /workspace/aind-dynamic-foraging-models
 
 WORKDIR /workspace/aind-disrnn-wrapper/code
 ENV PYTHONPATH=/workspace/aind-disrnn-wrapper/code

--- a/beaker/Dockerfile
+++ b/beaker/Dockerfile
@@ -1,12 +1,13 @@
 # Beaker (AI Hub) image for the disRNN wrapper — GPU.
 #
-# Clones BOTH repos from GitHub in the sibling layout that run_hpc.py expects:
+# Clones the dispatcher, wrapper, and dynamic-foraging-models repos from GitHub.
+# The dispatcher and wrapper use the sibling layout that run_hpc.py expects:
 #   /workspace/aind-disrnn-wrapper/code/run_hpc.py reads its Hydra configs from
 #   ../../aind-disrnn-dispatcher/code/config  ->  /workspace/aind-disrnn-dispatcher/...
 # so W&B sweep agents (which invoke `python -m run_hpc <overrides>`) can
 # re-compose the config on Beaker with no code change.
 #
-# Because both repos are cloned from git, the build context is irrelevant — you
+# Because all repos are cloned from git, the build context is irrelevant — you
 # can build from anywhere. All repos/deps are public, so no token is needed:
 #
 #   docker build \
@@ -29,38 +30,44 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# Which refs to bake in. Default to the migration branch; override at build time
-# (e.g. --build-arg WRAPPER_REF=main) once merged. `-b` takes a branch or tag.
+# Which refs to bake in. Branches, tags, and full commit SHAs are supported.
 ARG GH_ORG=https://github.com/AllenNeuralDynamics
-ARG DISPATCHER_REF=ai_hub
-ARG WRAPPER_REF=ai_hub
+ARG DISPATCHER_REF=main
+ARG WRAPPER_REF=main
+ARG FORAGING_MODELS_REF=main
 
-# Clone both repos (sibling layout) and install the wrapper + GPU JAX. All repos
+# Clone all three repos and install the wrapper + GPU JAX. All repos
 # and the wrapper's git deps (disentangled-rnns, aind-disrnn-utils) are public,
 # so no credentials are needed.
 #
 # The baked code is only a STARTING POINT: at job startup beaker/entrypoint.sh
-# re-pulls both repos to the latest ref (default ai_hub), so the image rarely
-# needs rebuilding — only when DEPENDENCIES change. The build-time clone exists
+# re-pulls all three repos to the requested refs (default main), so the image
+# rarely needs rebuilding — only when DEPENDENCIES change. The build-time clone exists
 # mainly to (a) install deps from pyproject and (b) seed the repos so entrypoint.sh
 # can `git fetch` them. See beaker/entrypoint.sh and the README.
 #
-# Trade-off: pinned to branch tips (ai_hub), so the image is reproducible only as
-# far as "whatever ai_hub pointed at when built" — not a commit SHA. For release
-# images, point the *_REF args at tags/SHAs (a tag works with `-b`; a bare SHA
-# needs a fetch+checkout instead of --depth 1 -b).
+# For release images, point all *_REF args at full commit SHAs.
 #
 # CACHEBUST: the clone instruction text is identical across builds, so Docker
 # would otherwise reuse a stale cached clone and silently bake old code. Pass a
 # changing value (build_and_push.sh sends a timestamp) to force a fresh clone +
 # reinstall whenever you intentionally rebuild.
 ARG CACHEBUST=0
-RUN echo "cachebust=$CACHEBUST" && \
-    git clone --depth 1 -b "$DISPATCHER_REF" \
-      "$GH_ORG/aind-disrnn-dispatcher.git" /workspace/aind-disrnn-dispatcher && \
-    git clone --depth 1 -b "$WRAPPER_REF" \
-      "$GH_ORG/aind-disrnn-wrapper.git" /workspace/aind-disrnn-wrapper && \
-    pip install --no-cache-dir -e "/workspace/aind-disrnn-wrapper[gpu]"
+RUN clone_ref() { \
+      repo="$1"; dir="$2"; ref="$3"; \
+      git clone --depth 1 "$repo" "$dir"; \
+      git -C "$dir" fetch --depth 1 origin "$ref"; \
+      git -C "$dir" checkout -f --detach FETCH_HEAD; \
+    }; \
+    echo "cachebust=$CACHEBUST" && \
+    clone_ref "$GH_ORG/aind-disrnn-dispatcher.git" \
+      /workspace/aind-disrnn-dispatcher "$DISPATCHER_REF" && \
+    clone_ref "$GH_ORG/aind-dynamic-foraging-models.git" \
+      /workspace/aind-dynamic-foraging-models "$FORAGING_MODELS_REF" && \
+    clone_ref "$GH_ORG/aind-disrnn-wrapper.git" \
+      /workspace/aind-disrnn-wrapper "$WRAPPER_REF" && \
+    pip install --no-cache-dir -e "/workspace/aind-disrnn-wrapper[gpu]" && \
+    pip install --no-cache-dir -e /workspace/aind-dynamic-foraging-models
 
 WORKDIR /workspace/aind-disrnn-wrapper/code
 ENV PYTHONPATH=/workspace/aind-disrnn-wrapper/code

--- a/beaker/Dockerfile
+++ b/beaker/Dockerfile
@@ -1,6 +1,6 @@
 # Beaker (AI Hub) image for the disRNN wrapper — GPU.
 #
-# Clones the dispatcher, wrapper, and dynamic-foraging-models repos from GitHub.
+# Clones the four runtime source repos from GitHub.
 # The dispatcher and wrapper use the sibling layout that run_hpc.py expects:
 #   /workspace/aind-disrnn-wrapper/code/run_hpc.py reads its Hydra configs from
 #   ../../aind-disrnn-dispatcher/code/config  ->  /workspace/aind-disrnn-dispatcher/...
@@ -35,13 +35,14 @@ ARG GH_ORG=https://github.com/AllenNeuralDynamics
 ARG DISPATCHER_REF=main
 ARG WRAPPER_REF=main
 ARG FORAGING_MODELS_REF=main
+ARG DISENTANGLED_RNNS_REF=main
 
-# Clone all three repos and install the wrapper + GPU JAX. All repos
+# Clone all four repos and install the wrapper + GPU JAX. All repos
 # and the wrapper's git deps (disentangled-rnns, aind-disrnn-utils) are public,
 # so no credentials are needed.
 #
 # The baked code is only a STARTING POINT: at job startup beaker/entrypoint.sh
-# re-pulls all three repos to the requested refs (default main), so the image
+# re-pulls all four repos to the requested refs (default main), so the image
 # rarely needs rebuilding — only when DEPENDENCIES change. The build-time clone exists
 # mainly to (a) install deps from pyproject and (b) seed the repos so entrypoint.sh
 # can `git fetch` them. See beaker/entrypoint.sh and the README.
@@ -64,10 +65,13 @@ RUN clone_ref() { \
       /workspace/aind-disrnn-dispatcher "$DISPATCHER_REF" && \
     clone_ref "$GH_ORG/aind-dynamic-foraging-models.git" \
       /workspace/aind-dynamic-foraging-models "$FORAGING_MODELS_REF" && \
+    clone_ref "$GH_ORG/aind-disentangled-rnns.git" \
+      /workspace/aind-disentangled-rnns "$DISENTANGLED_RNNS_REF" && \
     clone_ref "$GH_ORG/aind-disrnn-wrapper.git" \
       /workspace/aind-disrnn-wrapper "$WRAPPER_REF" && \
     pip install --no-cache-dir -e "/workspace/aind-disrnn-wrapper[gpu]" && \
-    pip install --no-cache-dir -e /workspace/aind-dynamic-foraging-models
+    pip install --no-cache-dir -e /workspace/aind-dynamic-foraging-models && \
+    pip install --no-cache-dir -e /workspace/aind-disentangled-rnns
 
 WORKDIR /workspace/aind-disrnn-wrapper/code
 ENV PYTHONPATH=/workspace/aind-disrnn-wrapper/code

--- a/beaker/README.md
+++ b/beaker/README.md
@@ -17,10 +17,11 @@ Run the disRNN training stack on the Allen **AI Hub / Beaker** GPU platform.
   W&B sweep and submits the Beaker experiment. No GPU, no Docker.
 
 **Key idea — code is *not* frozen in the image.** The image bakes only the
-environment (Python + JAX + pinned deps). The wrapper, dispatcher, and
-`aind-dynamic-foraging-models` sources are pulled fresh from GitHub at job startup
-by `entrypoint.sh`, so day-to-day you just **edit → push → re-run**, never rebuild.
-See [Controlling the code version](#3-controlling-the-code-version).
+environment (Python + JAX + pinned deps). The wrapper, dispatcher,
+`aind-dynamic-foraging-models`, and `aind-disentangled-rnns` sources are pulled
+fresh from GitHub at job startup by `entrypoint.sh`, so day-to-day you just
+**edit → push → re-run**, never rebuild. See
+[Controlling the code version](#3-controlling-the-code-version).
 
 ## Migration status
 
@@ -31,20 +32,21 @@ Where the CO → Beaker migration stands (this section is the running log).
 
 1. **Beaker access** — CLI installed (via `environment/postInstall` in the dispatcher),
    `BEAKER_TOKEN` auth confirmed; workspace + cluster reachable from Code Ocean.
-2. **Image build** — `Dockerfile` git-clones all three repos + installs deps; built on a
+2. **Image build** — `Dockerfile` git-clones all four repos + installs deps; built on a
    Mac (`build_and_push.sh`, `--platform linux/amd64`) and pushed to Beaker's registry
    as `han-hou/disrnn-wrapper`. CO can't build (seccomp), so the Mac is the build box.
-3. **Runtime code-pull** — `entrypoint.sh` git-fetches all three repos to
-   `WRAPPER_REF`/`DISPATCHER_REF`/`FORAGING_MODELS_REF` at job start → **code edits
-   need no rebuild**.
+3. **Runtime code-pull** — `entrypoint.sh` git-fetches all four repos to
+   `WRAPPER_REF`/`DISPATCHER_REF`/`FORAGING_MODELS_REF`/`DISENTANGLED_RNNS_REF`
+   at job start → **code edits need no rebuild**.
 4. **Smoke test** — `smoke.yaml` confirmed image pull + runtime pull + GPU visible +
    Hydra config composition, no W&B.
 5. **Control plane** — the dispatcher's `launch_beaker.py` creates a W&B sweep, saves a
    reproducibility record to `/results`, and submits the Beaker experiment (the
    dispatcher → wrapper hand-off, mirroring CO). A 1-point MVP run succeeded.
 6. **Reproducibility** — each run stamps `wrapper_commit` / `dispatcher_commit` /
-   `foraging_models_commit` / `CO_COMPUTATION_ID` into its W&B config; the dispatcher
-   saves the sweep YAML + IDs + commit to `/results`.
+   `foraging_models_commit` / `disentangled_rnns_commit` / `CO_COMPUTATION_ID`
+   into its W&B config; the dispatcher saves the sweep YAML + IDs + commit to
+   `/results`.
 7. **Scale-out (array of jobs)** — `replicas: 4` validated: 4 `wandb agent`s across 4
    GPUs sharing one sweep (`experiment_scaling.yaml`).
 
@@ -175,7 +177,7 @@ eval-throttling (item 10) were both tested and gave nothing. For *scale*, use
 
 | File | What it is | Rebuild image to change? |
 |---|---|---|
-| `Dockerfile` | GPU image: clones all three runtime repos + installs deps | **Yes** |
+| `Dockerfile` | GPU image: clones all four runtime repos + installs deps | **Yes** |
 | `entrypoint.sh` | Runtime bootstrap: pulls latest code, then `exec`s the job | **Yes** (baked, runs before the pull) |
 | `build_and_push.sh` | Builds (`linux/amd64`) and pushes via `beaker image create` | n/a |
 | `BUILD_LOG.md` | Registry metadata and dependency rationale for each image build | n/a |
@@ -224,9 +226,10 @@ beaker image get disrnn-wrapper   # note the ref: han-hou/disrnn-wrapper
 |---|---|---|
 | `--name NAME` | Beaker image name | `disrnn-wrapper` |
 | `--workspace WS` | Beaker workspace | `ai1/aind-dynamic-foraging-foundation-model` |
-| `--ref REF` | Branch/tag/SHA baked into all three repos | `main` |
+| `--ref REF` | Branch/tag/SHA baked into all four repos | `main` |
 | `--wrapper-ref` / `--dispatcher-ref` | Override one repo's baked ref | `main` |
 | `--foraging-models-ref` | Override the models repo's baked ref | `main` |
+| `--disentangled-rnns-ref` | Override the disentangled-RNN repo's baked ref | `main` |
 | `--force-rebuild` | Bust Docker's cache → fresh clone + reinstall | off |
 | `--force-override-beaker` | Replace an existing Beaker image (delete only after a successful build) | off |
 
@@ -261,9 +264,10 @@ plane — `wandb sweep` → submit `experiment_mvp.yaml` — documented in
 
 ## 3. Controlling the code version
 
-At container startup `entrypoint.sh` `git fetch`es the wrapper, dispatcher, and
-`aind-dynamic-foraging-models` repos to `WRAPPER_REF`, `DISPATCHER_REF`, and
-`FORAGING_MODELS_REF` (default `main`), exports their resolved commits for W&B
+At container startup `entrypoint.sh` `git fetch`es the wrapper, dispatcher,
+`aind-dynamic-foraging-models`, and `aind-disentangled-rnns` repos to
+`WRAPPER_REF`, `DISPATCHER_REF`, `FORAGING_MODELS_REF`, and
+`DISENTANGLED_RNNS_REF` (default `main`), exports their resolved commits for W&B
 provenance, then `exec`s the job. The Beaker spec invokes it as:
 
 ```yaml
@@ -280,13 +284,14 @@ Consequences:
     - { name: WRAPPER_REF,    value: my-feature-branch }   # branch, tag, or SHA
     - { name: DISPATCHER_REF, value: my-feature-branch }
     - { name: FORAGING_MODELS_REF, value: my-models-branch }
+    - { name: DISENTANGLED_RNNS_REF, value: my-disrnn-branch }
   ```
   Omit them and they default to `main`. Use **SHAs** to pin a run for
   reproducibility.
 - **Build-time refs don't matter for what runs.** The Dockerfile/`build_and_push.sh`
   refs only seed the baked clone; the runtime pull overwrites it.
 - **Rebuild only on dependency changes** (`pyproject.toml` / pinned git deps,
-  including new dependencies added by `aind-dynamic-foraging-models`).
+  including new dependencies added by either dynamically refreshed library).
   Symptom: a run fails with `ImportError` / `ModuleNotFoundError` after a pull.
 
 ## 3b. Staged horizons — "extend later" (continue from a prior run)

--- a/beaker/README.md
+++ b/beaker/README.md
@@ -17,11 +17,10 @@ Run the disRNN training stack on the Allen **AI Hub / Beaker** GPU platform.
   W&B sweep and submits the Beaker experiment. No GPU, no Docker.
 
 **Key idea — code is *not* frozen in the image.** The image bakes only the
-environment (Python + JAX + pinned deps). The wrapper, dispatcher,
-`aind-dynamic-foraging-models`, and `aind-disentangled-rnns` sources are pulled
-fresh from GitHub at job startup by `entrypoint.sh`, so day-to-day you just
-**edit → push → re-run**, never rebuild. See
-[Controlling the code version](#3-controlling-the-code-version).
+environment (Python + JAX + pinned deps). The wrapper, dispatcher, and
+`aind-dynamic-foraging-models` sources are pulled fresh from GitHub at job startup
+by `entrypoint.sh`, so day-to-day you just **edit → push → re-run**, never rebuild.
+See [Controlling the code version](#3-controlling-the-code-version).
 
 ## Migration status
 
@@ -32,21 +31,20 @@ Where the CO → Beaker migration stands (this section is the running log).
 
 1. **Beaker access** — CLI installed (via `environment/postInstall` in the dispatcher),
    `BEAKER_TOKEN` auth confirmed; workspace + cluster reachable from Code Ocean.
-2. **Image build** — `Dockerfile` git-clones all four repos + installs deps; built on a
+2. **Image build** — `Dockerfile` git-clones all three repos + installs deps; built on a
    Mac (`build_and_push.sh`, `--platform linux/amd64`) and pushed to Beaker's registry
    as `han-hou/disrnn-wrapper`. CO can't build (seccomp), so the Mac is the build box.
-3. **Runtime code-pull** — `entrypoint.sh` git-fetches all four repos to
-   `WRAPPER_REF`/`DISPATCHER_REF`/`FORAGING_MODELS_REF`/`DISENTANGLED_RNNS_REF`
-   at job start → **code edits need no rebuild**.
+3. **Runtime code-pull** — `entrypoint.sh` git-fetches all three repos to
+   `WRAPPER_REF`/`DISPATCHER_REF`/`FORAGING_MODELS_REF` at job start → **code edits
+   need no rebuild**.
 4. **Smoke test** — `smoke.yaml` confirmed image pull + runtime pull + GPU visible +
    Hydra config composition, no W&B.
 5. **Control plane** — the dispatcher's `launch_beaker.py` creates a W&B sweep, saves a
    reproducibility record to `/results`, and submits the Beaker experiment (the
    dispatcher → wrapper hand-off, mirroring CO). A 1-point MVP run succeeded.
 6. **Reproducibility** — each run stamps `wrapper_commit` / `dispatcher_commit` /
-   `foraging_models_commit` / `disentangled_rnns_commit` / `CO_COMPUTATION_ID`
-   into its W&B config; the dispatcher saves the sweep YAML + IDs + commit to
-   `/results`.
+   `foraging_models_commit` / `CO_COMPUTATION_ID` into its W&B config; the dispatcher
+   saves the sweep YAML + IDs + commit to `/results`.
 7. **Scale-out (array of jobs)** — `replicas: 4` validated: 4 `wandb agent`s across 4
    GPUs sharing one sweep (`experiment_scaling.yaml`).
 
@@ -177,7 +175,7 @@ eval-throttling (item 10) were both tested and gave nothing. For *scale*, use
 
 | File | What it is | Rebuild image to change? |
 |---|---|---|
-| `Dockerfile` | GPU image: clones all four runtime repos + installs deps | **Yes** |
+| `Dockerfile` | GPU image: clones all three runtime repos + installs deps | **Yes** |
 | `entrypoint.sh` | Runtime bootstrap: pulls latest code, then `exec`s the job | **Yes** (baked, runs before the pull) |
 | `build_and_push.sh` | Builds (`linux/amd64`) and pushes via `beaker image create` | n/a |
 | `BUILD_LOG.md` | Registry metadata and dependency rationale for each image build | n/a |
@@ -226,10 +224,9 @@ beaker image get disrnn-wrapper   # note the ref: han-hou/disrnn-wrapper
 |---|---|---|
 | `--name NAME` | Beaker image name | `disrnn-wrapper` |
 | `--workspace WS` | Beaker workspace | `ai1/aind-dynamic-foraging-foundation-model` |
-| `--ref REF` | Branch/tag/SHA baked into all four repos | `main` |
+| `--ref REF` | Branch/tag/SHA baked into all three repos | `main` |
 | `--wrapper-ref` / `--dispatcher-ref` | Override one repo's baked ref | `main` |
 | `--foraging-models-ref` | Override the models repo's baked ref | `main` |
-| `--disentangled-rnns-ref` | Override the disentangled-RNN repo's baked ref | `main` |
 | `--force-rebuild` | Bust Docker's cache → fresh clone + reinstall | off |
 | `--force-override-beaker` | Replace an existing Beaker image (delete only after a successful build) | off |
 
@@ -264,10 +261,9 @@ plane — `wandb sweep` → submit `experiment_mvp.yaml` — documented in
 
 ## 3. Controlling the code version
 
-At container startup `entrypoint.sh` `git fetch`es the wrapper, dispatcher,
-`aind-dynamic-foraging-models`, and `aind-disentangled-rnns` repos to
-`WRAPPER_REF`, `DISPATCHER_REF`, `FORAGING_MODELS_REF`, and
-`DISENTANGLED_RNNS_REF` (default `main`), exports their resolved commits for W&B
+At container startup `entrypoint.sh` `git fetch`es the wrapper, dispatcher, and
+`aind-dynamic-foraging-models` repos to `WRAPPER_REF`, `DISPATCHER_REF`, and
+`FORAGING_MODELS_REF` (default `main`), exports their resolved commits for W&B
 provenance, then `exec`s the job. The Beaker spec invokes it as:
 
 ```yaml
@@ -284,14 +280,13 @@ Consequences:
     - { name: WRAPPER_REF,    value: my-feature-branch }   # branch, tag, or SHA
     - { name: DISPATCHER_REF, value: my-feature-branch }
     - { name: FORAGING_MODELS_REF, value: my-models-branch }
-    - { name: DISENTANGLED_RNNS_REF, value: my-disrnn-branch }
   ```
   Omit them and they default to `main`. Use **SHAs** to pin a run for
   reproducibility.
 - **Build-time refs don't matter for what runs.** The Dockerfile/`build_and_push.sh`
   refs only seed the baked clone; the runtime pull overwrites it.
 - **Rebuild only on dependency changes** (`pyproject.toml` / pinned git deps,
-  including new dependencies added by either dynamically refreshed library).
+  including new dependencies added by `aind-dynamic-foraging-models`).
   Symptom: a run fails with `ImportError` / `ModuleNotFoundError` after a pull.
 
 ## 3b. Staged horizons — "extend later" (continue from a prior run)

--- a/beaker/README.md
+++ b/beaker/README.md
@@ -176,6 +176,7 @@ eval-throttling (item 10) were both tested and gave nothing. For *scale*, use
 | `Dockerfile` | GPU image: clones both repos (sibling layout) + installs deps | **Yes** |
 | `entrypoint.sh` | Runtime bootstrap: pulls latest code, then `exec`s the job | **Yes** (baked, runs before the pull) |
 | `build_and_push.sh` | Builds (`linux/amd64`) and pushes via `beaker image create` | n/a |
+| `BUILD_LOG.md` | Registry metadata and dependency rationale for each image build | n/a |
 | `smoke.yaml` | Beaker spec: image sanity check (GPU + config, no W&B) | No |
 | `pack_gpu.sh` | Time-slicing: pack M `wandb agent`s onto one GPU | No (pulled at runtime, like the app code) |
 
@@ -191,7 +192,7 @@ eval-throttling (item 10) were both tested and gave nothing. For *scale*, use
 |---|---|
 | Workspace | `ai1/aind-dynamic-foraging-foundation-model` |
 | Cluster (L40s) | `ai1/octo-hub-aws-l40s` |
-| Image ref | `han-hou/disrnn-wrapper-pck-integration-20260630` — the original `han-hou/disrnn-wrapper` **no longer exists** (`ImageNotFound`). Authoritative list: the dispatcher's `code/beaker/README.md` "Available images" table, or `beaker workspace images ai1/aind-dynamic-foraging-foundation-model` |
+| Image ref | `han-hou/disrnn-wrapper-pck-integration-20260630` — the original `han-hou/disrnn-wrapper` **no longer exists** (`ImageNotFound`). Build history: [`BUILD_LOG.md`](BUILD_LOG.md). Authoritative live list: `beaker workspace images ai1/aind-dynamic-foraging-foundation-model` |
 | W&B secret | `han-wandb-api-key` (a Beaker secret holding `WANDB_API_KEY`) |
 
 ---
@@ -232,6 +233,9 @@ real dependency-change rebuild is therefore:
 ```bash
 bash beaker/build_and_push.sh --force-rebuild --force-override-beaker
 ```
+
+After a successful push, add the Beaker image ID, registry timestamps, exact
+baked refs, and rebuild reason to [`BUILD_LOG.md`](BUILD_LOG.md).
 
 > Apple Silicon builds `linux/amd64` under emulation (Beaker nodes are x86) — slower
 > but correct; the flag is already set. The image name/ref stays stable across

--- a/beaker/README.md
+++ b/beaker/README.md
@@ -6,7 +6,7 @@ Run the disRNN training stack on the Allen **AI Hub / Beaker** GPU platform.
 > image, the runtime code-pull, and the GPU benchmark results. The **control plane**
 > — defining W&B sweeps, experiment specs, clusters, and submitting jobs — lives in
 > the dispatcher:
-> [`aind-disrnn-dispatcher/code/beaker/README.md`](https://github.com/AllenNeuralDynamics/aind-disrnn-dispatcher/blob/ai_hub/code/beaker/README.md).
+> [`aind-disrnn-dispatcher/code/beaker/README.md`](https://github.com/AllenNeuralDynamics/aind-disrnn-dispatcher/blob/main/code/beaker/README.md).
 
 **Architecture (two planes):**
 - **Build plane — a Mac (or any box with Docker).** Builds the GPU image and
@@ -17,9 +17,10 @@ Run the disRNN training stack on the Allen **AI Hub / Beaker** GPU platform.
   W&B sweep and submits the Beaker experiment. No GPU, no Docker.
 
 **Key idea — code is *not* frozen in the image.** The image bakes only the
-environment (Python + JAX + pinned deps). The actual code is pulled fresh from
-GitHub at job startup by `entrypoint.sh`, so day-to-day you just **edit → push →
-re-run**, never rebuild. See [Controlling the code version](#3-controlling-the-code-version).
+environment (Python + JAX + pinned deps). The wrapper, dispatcher, and
+`aind-dynamic-foraging-models` sources are pulled fresh from GitHub at job startup
+by `entrypoint.sh`, so day-to-day you just **edit → push → re-run**, never rebuild.
+See [Controlling the code version](#3-controlling-the-code-version).
 
 ## Migration status
 
@@ -30,19 +31,20 @@ Where the CO → Beaker migration stands (this section is the running log).
 
 1. **Beaker access** — CLI installed (via `environment/postInstall` in the dispatcher),
    `BEAKER_TOKEN` auth confirmed; workspace + cluster reachable from Code Ocean.
-2. **Image build** — `Dockerfile` git-clones both repos + installs deps; built on a
+2. **Image build** — `Dockerfile` git-clones all three repos + installs deps; built on a
    Mac (`build_and_push.sh`, `--platform linux/amd64`) and pushed to Beaker's registry
    as `han-hou/disrnn-wrapper`. CO can't build (seccomp), so the Mac is the build box.
-3. **Runtime code-pull** — `entrypoint.sh` git-fetches both repos to
-   `WRAPPER_REF`/`DISPATCHER_REF` at job start → **code edits need no rebuild**.
+3. **Runtime code-pull** — `entrypoint.sh` git-fetches all three repos to
+   `WRAPPER_REF`/`DISPATCHER_REF`/`FORAGING_MODELS_REF` at job start → **code edits
+   need no rebuild**.
 4. **Smoke test** — `smoke.yaml` confirmed image pull + runtime pull + GPU visible +
    Hydra config composition, no W&B.
 5. **Control plane** — the dispatcher's `launch_beaker.py` creates a W&B sweep, saves a
    reproducibility record to `/results`, and submits the Beaker experiment (the
    dispatcher → wrapper hand-off, mirroring CO). A 1-point MVP run succeeded.
 6. **Reproducibility** — each run stamps `wrapper_commit` / `dispatcher_commit` /
-   `CO_COMPUTATION_ID` into its W&B config; the dispatcher saves the sweep YAML + IDs +
-   commit to `/results`.
+   `foraging_models_commit` / `CO_COMPUTATION_ID` into its W&B config; the dispatcher
+   saves the sweep YAML + IDs + commit to `/results`.
 7. **Scale-out (array of jobs)** — `replicas: 4` validated: 4 `wandb agent`s across 4
    GPUs sharing one sweep (`experiment_scaling.yaml`).
 
@@ -173,7 +175,7 @@ eval-throttling (item 10) were both tested and gave nothing. For *scale*, use
 
 | File | What it is | Rebuild image to change? |
 |---|---|---|
-| `Dockerfile` | GPU image: clones both repos (sibling layout) + installs deps | **Yes** |
+| `Dockerfile` | GPU image: clones all three runtime repos + installs deps | **Yes** |
 | `entrypoint.sh` | Runtime bootstrap: pulls latest code, then `exec`s the job | **Yes** (baked, runs before the pull) |
 | `build_and_push.sh` | Builds (`linux/amd64`) and pushes via `beaker image create` | n/a |
 | `BUILD_LOG.md` | Registry metadata and dependency rationale for each image build | n/a |
@@ -182,7 +184,7 @@ eval-throttling (item 10) were both tested and gave nothing. For *scale*, use
 
 > The sweep definition and the production Beaker job spec live in the **dispatcher**
 > (control plane), not here —
-> [`aind-disrnn-dispatcher/code/beaker/`](https://github.com/AllenNeuralDynamics/aind-disrnn-dispatcher/blob/ai_hub/code/beaker/README.md)
+> [`aind-disrnn-dispatcher/code/beaker/`](https://github.com/AllenNeuralDynamics/aind-disrnn-dispatcher/blob/main/code/beaker/README.md)
 > (`sweep_mvp.yaml`, `experiment_mvp.yaml`). This repo only builds the image and
 > ships `smoke.yaml` to test it.
 
@@ -211,7 +213,7 @@ beaker account login              # browser login with AI1 creds
 beaker account whoami             # expect: han-hou
 
 git clone https://github.com/AllenNeuralDynamics/aind-disrnn-wrapper.git
-cd aind-disrnn-wrapper && git checkout ai_hub
+cd aind-disrnn-wrapper && git checkout main
 bash beaker/build_and_push.sh
 beaker image get disrnn-wrapper   # note the ref: han-hou/disrnn-wrapper
 ```
@@ -222,8 +224,9 @@ beaker image get disrnn-wrapper   # note the ref: han-hou/disrnn-wrapper
 |---|---|---|
 | `--name NAME` | Beaker image name | `disrnn-wrapper` |
 | `--workspace WS` | Beaker workspace | `ai1/aind-dynamic-foraging-foundation-model` |
-| `--ref REF` | Branch/tag/SHA baked into **both** repos | `ai_hub` |
-| `--wrapper-ref` / `--dispatcher-ref` | Override one repo's baked ref | `ai_hub` |
+| `--ref REF` | Branch/tag/SHA baked into all three repos | `main` |
+| `--wrapper-ref` / `--dispatcher-ref` | Override one repo's baked ref | `main` |
+| `--foraging-models-ref` | Override the models repo's baked ref | `main` |
 | `--force-rebuild` | Bust Docker's cache → fresh clone + reinstall | off |
 | `--force-override-beaker` | Replace an existing Beaker image (delete only after a successful build) | off |
 
@@ -254,13 +257,14 @@ beaker experiment create -w "$WS" beaker/smoke.yaml
 
 **To actually run training** (the W&B-sweep MVP), use the **dispatcher** control
 plane — `wandb sweep` → submit `experiment_mvp.yaml` — documented in
-[`aind-disrnn-dispatcher/code/beaker/README.md`](https://github.com/AllenNeuralDynamics/aind-disrnn-dispatcher/blob/ai_hub/code/beaker/README.md).
+[`aind-disrnn-dispatcher/code/beaker/README.md`](https://github.com/AllenNeuralDynamics/aind-disrnn-dispatcher/blob/main/code/beaker/README.md).
 
 ## 3. Controlling the code version
 
-At container startup `entrypoint.sh` `git fetch`es **both** repos to
-`WRAPPER_REF` / `DISPATCHER_REF` (default `ai_hub`), logs the resolved commit
-SHAs, then `exec`s the job. The Beaker spec invokes it as:
+At container startup `entrypoint.sh` `git fetch`es the wrapper, dispatcher, and
+`aind-dynamic-foraging-models` repos to `WRAPPER_REF`, `DISPATCHER_REF`, and
+`FORAGING_MODELS_REF` (default `main`), exports their resolved commits for W&B
+provenance, then `exec`s the job. The Beaker spec invokes it as:
 
 ```yaml
 command: [bash, /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh, wandb, agent, ...]
@@ -268,19 +272,21 @@ command: [bash, /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh, wandb, agen
 
 Consequences:
 
-- **Iterate without rebuilding:** edit → push to `ai_hub` → submit a new run.
+- **Iterate without rebuilding:** edit → push → submit a new run.
 - **Run a different branch / commit:** set the refs in the spec you submit — this
   is the *only* knob that affects what runs:
   ```yaml
   envVars:
     - { name: WRAPPER_REF,    value: my-feature-branch }   # branch, tag, or SHA
     - { name: DISPATCHER_REF, value: my-feature-branch }
+    - { name: FORAGING_MODELS_REF, value: my-models-branch }
   ```
-  Omit them and it defaults to `ai_hub`. Use a **SHA** to pin a run for
+  Omit them and they default to `main`. Use **SHAs** to pin a run for
   reproducibility.
 - **Build-time refs don't matter for what runs.** The Dockerfile/`build_and_push.sh`
   refs only seed the baked clone; the runtime pull overwrites it.
-- **Rebuild only on dependency changes** (`pyproject.toml` / pinned git deps).
+- **Rebuild only on dependency changes** (`pyproject.toml` / pinned git deps,
+  including new dependencies added by `aind-dynamic-foraging-models`).
   Symptom: a run fails with `ImportError` / `ModuleNotFoundError` after a pull.
 
 ## 3b. Staged horizons — "extend later" (continue from a prior run)
@@ -316,8 +322,8 @@ Two resume mechanisms exist; they compose:
 | Want to change… | Edit | Rebuild image? |
 |---|---|---|
 | **Dependencies / base environment** | `Dockerfile` (then `pyproject.toml` for the actual deps) | **Yes** — `--force-rebuild --force-override-beaker` |
-| **The command, cluster, GPU count, replicas, secret, refs** | the spec YAML — `smoke.yaml` (here) or `experiment_mvp.yaml` ([dispatcher](https://github.com/AllenNeuralDynamics/aind-disrnn-dispatcher/blob/ai_hub/code/beaker/README.md)) | No |
-| **The hyperparameter grid / `run_hpc` overrides** | `sweep_mvp.yaml` in the [dispatcher](https://github.com/AllenNeuralDynamics/aind-disrnn-dispatcher/blob/ai_hub/code/beaker/README.md) (read by `wandb sweep` at submit) | No |
+| **The command, cluster, GPU count, replicas, secret, refs** | the spec YAML — `smoke.yaml` (here) or `experiment_mvp.yaml` ([dispatcher](https://github.com/AllenNeuralDynamics/aind-disrnn-dispatcher/blob/main/code/beaker/README.md)) | No |
+| **The hyperparameter grid / `run_hpc` overrides** | `sweep_mvp.yaml` in the [dispatcher](https://github.com/AllenNeuralDynamics/aind-disrnn-dispatcher/blob/main/code/beaker/README.md) (read by `wandb sweep` at submit) | No |
 | **The startup/bootstrap logic** (how code is pulled) | `entrypoint.sh` | **Yes** (it's baked and runs before the pull) |
 | **Application code / Hydra configs** | the wrapper / dispatcher repos directly | No — push to the ref the job uses |
 

--- a/beaker/README.md
+++ b/beaker/README.md
@@ -194,7 +194,7 @@ eval-throttling (item 10) were both tested and gave nothing. For *scale*, use
 |---|---|
 | Workspace | `ai1/aind-dynamic-foraging-foundation-model` |
 | Cluster (L40s) | `ai1/octo-hub-aws-l40s` |
-| Image ref | `han-hou/disrnn-wrapper-pck-integration-20260630` — the original `han-hou/disrnn-wrapper` **no longer exists** (`ImageNotFound`). Build history: [`BUILD_LOG.md`](BUILD_LOG.md). Authoritative live list: `beaker workspace images ai1/aind-dynamic-foraging-foundation-model` |
+| Image ref | `han-hou/disrnn-wrapper-main-20260712` — the original `han-hou/disrnn-wrapper` **no longer exists** (`ImageNotFound`). Build history: [`BUILD_LOG.md`](BUILD_LOG.md). Authoritative live list: `beaker workspace images ai1/aind-dynamic-foraging-foundation-model` |
 | W&B secret | `han-wandb-api-key` (a Beaker secret holding `WANDB_API_KEY`) |
 
 ---

--- a/beaker/build_and_push.sh
+++ b/beaker/build_and_push.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Build the disRNN wrapper GPU image and push it to Beaker's registry.
 #
-# The Dockerfile git-clones both repos itself (all public, no token needed), so
+# The Dockerfile git-clones all three repos itself (all public, no token needed), so
 # there is no build context to stage and you can run this from anywhere.
 #
 # Usage:
@@ -10,9 +10,11 @@
 # Options:
 #   --name NAME             Beaker image name (default: disrnn-wrapper)
 #   --workspace WS          Beaker workspace (default: ai1/aind-dynamic-foraging-foundation-model)
-#   --ref REF              Branch/tag/SHA to bake into BOTH repos (default: ai_hub)
+#   --ref REF               Branch/tag/SHA to bake into all repos (default: main)
 #   --wrapper-ref REF       Override the wrapper repo ref only
 #   --dispatcher-ref REF    Override the dispatcher repo ref only
+#   --foraging-models-ref REF
+#                           Override the aind-dynamic-foraging-models ref only
 #   --force-rebuild         Bust Docker's cache so the build does a FRESH clone +
 #                           reinstall (otherwise Docker reuses cached layers and
 #                           may bake stale code/deps).
@@ -27,8 +29,9 @@ set -euo pipefail
 # Defaults (override via the flags above — not env vars).
 IMAGE_NAME="disrnn-wrapper"
 WORKSPACE="ai1/aind-dynamic-foraging-foundation-model"
-WRAPPER_REF="ai_hub"
-DISPATCHER_REF="ai_hub"
+WRAPPER_REF="main"
+DISPATCHER_REF="main"
+FORAGING_MODELS_REF="main"
 FORCE_REBUILD=0
 FORCE_OVERRIDE_BEAKER=0
 
@@ -38,9 +41,10 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --name)                  IMAGE_NAME="$2"; shift 2 ;;
         --workspace)             WORKSPACE="$2"; shift 2 ;;
-        --ref)                   WRAPPER_REF="$2"; DISPATCHER_REF="$2"; shift 2 ;;
+        --ref)                   WRAPPER_REF="$2"; DISPATCHER_REF="$2"; FORAGING_MODELS_REF="$2"; shift 2 ;;
         --wrapper-ref)           WRAPPER_REF="$2"; shift 2 ;;
         --dispatcher-ref)        DISPATCHER_REF="$2"; shift 2 ;;
+        --foraging-models-ref)   FORAGING_MODELS_REF="$2"; shift 2 ;;
         --force-rebuild)         FORCE_REBUILD=1; shift ;;
         --force-override-beaker) FORCE_OVERRIDE_BEAKER=1; shift ;;
         -h|--help)               usage; exit 0 ;;
@@ -50,7 +54,8 @@ done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "image: $IMAGE_NAME   workspace: $WORKSPACE   refs: ${DISPATCHER_REF}/${WRAPPER_REF}"
+echo "image: $IMAGE_NAME   workspace: $WORKSPACE"
+echo "refs: dispatcher=${DISPATCHER_REF} wrapper=${WRAPPER_REF} foraging-models=${FORAGING_MODELS_REF}"
 echo "force-rebuild: $FORCE_REBUILD   force-override-beaker: $FORCE_OVERRIDE_BEAKER"
 
 # Pre-flight: Beaker image names are unique per workspace. If one already exists,
@@ -89,6 +94,7 @@ docker build \
     $cachebust_arg \
     --build-arg WRAPPER_REF="$WRAPPER_REF" \
     --build-arg DISPATCHER_REF="$DISPATCHER_REF" \
+    --build-arg FORAGING_MODELS_REF="$FORAGING_MODELS_REF" \
     -f "$SCRIPT_DIR/Dockerfile" \
     -t "$IMAGE_NAME" \
     "$SCRIPT_DIR"

--- a/beaker/build_and_push.sh
+++ b/beaker/build_and_push.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Build the disRNN wrapper GPU image and push it to Beaker's registry.
 #
-# The Dockerfile git-clones all four repos itself (all public, no token needed), so
+# The Dockerfile git-clones all three repos itself (all public, no token needed), so
 # there is no build context to stage and you can run this from anywhere.
 #
 # Usage:
@@ -15,8 +15,6 @@
 #   --dispatcher-ref REF    Override the dispatcher repo ref only
 #   --foraging-models-ref REF
 #                           Override the aind-dynamic-foraging-models ref only
-#   --disentangled-rnns-ref REF
-#                           Override the aind-disentangled-rnns ref only
 #   --force-rebuild         Bust Docker's cache so the build does a FRESH clone +
 #                           reinstall (otherwise Docker reuses cached layers and
 #                           may bake stale code/deps).
@@ -34,7 +32,6 @@ WORKSPACE="ai1/aind-dynamic-foraging-foundation-model"
 WRAPPER_REF="main"
 DISPATCHER_REF="main"
 FORAGING_MODELS_REF="main"
-DISENTANGLED_RNNS_REF="main"
 FORCE_REBUILD=0
 FORCE_OVERRIDE_BEAKER=0
 
@@ -44,11 +41,10 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --name)                  IMAGE_NAME="$2"; shift 2 ;;
         --workspace)             WORKSPACE="$2"; shift 2 ;;
-        --ref)                   WRAPPER_REF="$2"; DISPATCHER_REF="$2"; FORAGING_MODELS_REF="$2"; DISENTANGLED_RNNS_REF="$2"; shift 2 ;;
+        --ref)                   WRAPPER_REF="$2"; DISPATCHER_REF="$2"; FORAGING_MODELS_REF="$2"; shift 2 ;;
         --wrapper-ref)           WRAPPER_REF="$2"; shift 2 ;;
         --dispatcher-ref)        DISPATCHER_REF="$2"; shift 2 ;;
         --foraging-models-ref)   FORAGING_MODELS_REF="$2"; shift 2 ;;
-        --disentangled-rnns-ref) DISENTANGLED_RNNS_REF="$2"; shift 2 ;;
         --force-rebuild)         FORCE_REBUILD=1; shift ;;
         --force-override-beaker) FORCE_OVERRIDE_BEAKER=1; shift ;;
         -h|--help)               usage; exit 0 ;;
@@ -60,7 +56,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "image: $IMAGE_NAME   workspace: $WORKSPACE"
 echo "refs: dispatcher=${DISPATCHER_REF} wrapper=${WRAPPER_REF} foraging-models=${FORAGING_MODELS_REF}"
-echo "      disentangled-rnns=${DISENTANGLED_RNNS_REF}"
 echo "force-rebuild: $FORCE_REBUILD   force-override-beaker: $FORCE_OVERRIDE_BEAKER"
 
 # Pre-flight: Beaker image names are unique per workspace. If one already exists,
@@ -100,7 +95,6 @@ docker build \
     --build-arg WRAPPER_REF="$WRAPPER_REF" \
     --build-arg DISPATCHER_REF="$DISPATCHER_REF" \
     --build-arg FORAGING_MODELS_REF="$FORAGING_MODELS_REF" \
-    --build-arg DISENTANGLED_RNNS_REF="$DISENTANGLED_RNNS_REF" \
     -f "$SCRIPT_DIR/Dockerfile" \
     -t "$IMAGE_NAME" \
     "$SCRIPT_DIR"

--- a/beaker/build_and_push.sh
+++ b/beaker/build_and_push.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Build the disRNN wrapper GPU image and push it to Beaker's registry.
 #
-# The Dockerfile git-clones all three repos itself (all public, no token needed), so
+# The Dockerfile git-clones all four repos itself (all public, no token needed), so
 # there is no build context to stage and you can run this from anywhere.
 #
 # Usage:
@@ -15,6 +15,8 @@
 #   --dispatcher-ref REF    Override the dispatcher repo ref only
 #   --foraging-models-ref REF
 #                           Override the aind-dynamic-foraging-models ref only
+#   --disentangled-rnns-ref REF
+#                           Override the aind-disentangled-rnns ref only
 #   --force-rebuild         Bust Docker's cache so the build does a FRESH clone +
 #                           reinstall (otherwise Docker reuses cached layers and
 #                           may bake stale code/deps).
@@ -32,6 +34,7 @@ WORKSPACE="ai1/aind-dynamic-foraging-foundation-model"
 WRAPPER_REF="main"
 DISPATCHER_REF="main"
 FORAGING_MODELS_REF="main"
+DISENTANGLED_RNNS_REF="main"
 FORCE_REBUILD=0
 FORCE_OVERRIDE_BEAKER=0
 
@@ -41,10 +44,11 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --name)                  IMAGE_NAME="$2"; shift 2 ;;
         --workspace)             WORKSPACE="$2"; shift 2 ;;
-        --ref)                   WRAPPER_REF="$2"; DISPATCHER_REF="$2"; FORAGING_MODELS_REF="$2"; shift 2 ;;
+        --ref)                   WRAPPER_REF="$2"; DISPATCHER_REF="$2"; FORAGING_MODELS_REF="$2"; DISENTANGLED_RNNS_REF="$2"; shift 2 ;;
         --wrapper-ref)           WRAPPER_REF="$2"; shift 2 ;;
         --dispatcher-ref)        DISPATCHER_REF="$2"; shift 2 ;;
         --foraging-models-ref)   FORAGING_MODELS_REF="$2"; shift 2 ;;
+        --disentangled-rnns-ref) DISENTANGLED_RNNS_REF="$2"; shift 2 ;;
         --force-rebuild)         FORCE_REBUILD=1; shift ;;
         --force-override-beaker) FORCE_OVERRIDE_BEAKER=1; shift ;;
         -h|--help)               usage; exit 0 ;;
@@ -56,6 +60,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "image: $IMAGE_NAME   workspace: $WORKSPACE"
 echo "refs: dispatcher=${DISPATCHER_REF} wrapper=${WRAPPER_REF} foraging-models=${FORAGING_MODELS_REF}"
+echo "      disentangled-rnns=${DISENTANGLED_RNNS_REF}"
 echo "force-rebuild: $FORCE_REBUILD   force-override-beaker: $FORCE_OVERRIDE_BEAKER"
 
 # Pre-flight: Beaker image names are unique per workspace. If one already exists,
@@ -95,6 +100,7 @@ docker build \
     --build-arg WRAPPER_REF="$WRAPPER_REF" \
     --build-arg DISPATCHER_REF="$DISPATCHER_REF" \
     --build-arg FORAGING_MODELS_REF="$FORAGING_MODELS_REF" \
+    --build-arg DISENTANGLED_RNNS_REF="$DISENTANGLED_RNNS_REF" \
     -f "$SCRIPT_DIR/Dockerfile" \
     -t "$IMAGE_NAME" \
     "$SCRIPT_DIR"

--- a/beaker/entrypoint.sh
+++ b/beaker/entrypoint.sh
@@ -2,8 +2,8 @@
 # Runtime entrypoint for the disRNN Beaker image.
 #
 # Runs at CONTAINER STARTUP on every Beaker job (NOT at image build time): it
-# refreshes all four repos to the requested code on GitHub *before* running the
-# job, so code/config edits take effect by just launching a new run — no rebuild.
+# refreshes all three repos to the requested code on GitHub *before* running the job, so
+# code/config edits take effect by just launching a new run — no image rebuild.
 #
 # Invoked from the Beaker spec's `command`, e.g.:
 #   command: [bash, /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh,
@@ -17,14 +17,12 @@
 # Pin a run for reproducibility by passing commit SHAs instead of branches:
 #   envVars: [{name: WRAPPER_REF, value: <sha>},
 #             {name: DISPATCHER_REF, value: <sha>},
-#             {name: FORAGING_MODELS_REF, value: <sha>},
-#             {name: DISENTANGLED_RNNS_REF, value: <sha>}]
+#             {name: FORAGING_MODELS_REF, value: <sha>}]
 set -euo pipefail
 
 WRAPPER_REF="${WRAPPER_REF:-main}"
 DISPATCHER_REF="${DISPATCHER_REF:-main}"
 FORAGING_MODELS_REF="${FORAGING_MODELS_REF:-main}"
-DISENTANGLED_RNNS_REF="${DISENTANGLED_RNNS_REF:-main}"
 
 refresh() {  # <repo dir> <ref> <commit env var>
     local dir="$1" ref="$2" commit_env="$3" commit
@@ -41,7 +39,6 @@ refresh() {  # <repo dir> <ref> <commit env var>
 echo "[entrypoint] refreshing source from GitHub before the run..."
 refresh /workspace/aind-disrnn-dispatcher          "$DISPATCHER_REF"       DISPATCHER_COMMIT
 refresh /workspace/aind-dynamic-foraging-models    "$FORAGING_MODELS_REF"  FORAGING_MODELS_COMMIT
-refresh /workspace/aind-disentangled-rnns          "$DISENTANGLED_RNNS_REF" DISENTANGLED_RNNS_COMMIT
 refresh /workspace/aind-disrnn-wrapper             "$WRAPPER_REF"          WRAPPER_COMMIT
 
 if [ "$#" -eq 0 ]; then

--- a/beaker/entrypoint.sh
+++ b/beaker/entrypoint.sh
@@ -2,7 +2,7 @@
 # Runtime entrypoint for the disRNN Beaker image.
 #
 # Runs at CONTAINER STARTUP on every Beaker job (NOT at image build time): it
-# refreshes both repos to the latest code on GitHub *before* running the job, so
+# refreshes all three repos to the requested code on GitHub *before* running the job, so
 # code/config edits take effect by just launching a new run — no image rebuild.
 #
 # Invoked from the Beaker spec's `command`, e.g.:
@@ -14,25 +14,32 @@
 # the pinned git deps). Plain code or Hydra-config edits never need one. If a run
 # fails with ImportError/ModuleNotFound after a pull, that's the signal to rebuild.
 #
-# Pin a run for reproducibility by passing a commit SHA instead of the branch:
-#   envVars: [{name: WRAPPER_REF, value: <sha>}, {name: DISPATCHER_REF, value: <sha>}]
+# Pin a run for reproducibility by passing commit SHAs instead of branches:
+#   envVars: [{name: WRAPPER_REF, value: <sha>},
+#             {name: DISPATCHER_REF, value: <sha>},
+#             {name: FORAGING_MODELS_REF, value: <sha>}]
 set -euo pipefail
 
-WRAPPER_REF="${WRAPPER_REF:-ai_hub}"
-DISPATCHER_REF="${DISPATCHER_REF:-ai_hub}"
+WRAPPER_REF="${WRAPPER_REF:-main}"
+DISPATCHER_REF="${DISPATCHER_REF:-main}"
+FORAGING_MODELS_REF="${FORAGING_MODELS_REF:-main}"
 
-refresh() {  # <repo dir> <ref>
-    local dir="$1" ref="$2"
+refresh() {  # <repo dir> <ref> <commit env var>
+    local dir="$1" ref="$2" commit_env="$3" commit
     # --depth 1 keeps the shallow clone shallow; works for a branch, tag, or
     # (GitHub allows) a specific commit SHA. Detach at the fetched commit.
     git -C "$dir" fetch --depth 1 origin "$ref"
     git -C "$dir" checkout -f --detach FETCH_HEAD
-    echo "[entrypoint]   $(basename "$dir") @ ${ref} -> $(git -C "$dir" rev-parse --short HEAD)"
+    commit="$(git -C "$dir" rev-parse HEAD)"
+    printf -v "$commit_env" '%s' "$commit"
+    export "$commit_env"
+    echo "[entrypoint]   $(basename "$dir") @ ${ref} -> ${commit:0:7}"
 }
 
 echo "[entrypoint] refreshing source from GitHub before the run..."
-refresh /workspace/aind-disrnn-dispatcher "$DISPATCHER_REF"
-refresh /workspace/aind-disrnn-wrapper    "$WRAPPER_REF"
+refresh /workspace/aind-disrnn-dispatcher          "$DISPATCHER_REF"       DISPATCHER_COMMIT
+refresh /workspace/aind-dynamic-foraging-models    "$FORAGING_MODELS_REF"  FORAGING_MODELS_COMMIT
+refresh /workspace/aind-disrnn-wrapper             "$WRAPPER_REF"          WRAPPER_COMMIT
 
 if [ "$#" -eq 0 ]; then
     echo "[entrypoint] no command given; nothing to run." >&2

--- a/beaker/entrypoint.sh
+++ b/beaker/entrypoint.sh
@@ -2,8 +2,8 @@
 # Runtime entrypoint for the disRNN Beaker image.
 #
 # Runs at CONTAINER STARTUP on every Beaker job (NOT at image build time): it
-# refreshes all three repos to the requested code on GitHub *before* running the job, so
-# code/config edits take effect by just launching a new run — no image rebuild.
+# refreshes all four repos to the requested code on GitHub *before* running the
+# job, so code/config edits take effect by just launching a new run — no rebuild.
 #
 # Invoked from the Beaker spec's `command`, e.g.:
 #   command: [bash, /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh,
@@ -17,12 +17,14 @@
 # Pin a run for reproducibility by passing commit SHAs instead of branches:
 #   envVars: [{name: WRAPPER_REF, value: <sha>},
 #             {name: DISPATCHER_REF, value: <sha>},
-#             {name: FORAGING_MODELS_REF, value: <sha>}]
+#             {name: FORAGING_MODELS_REF, value: <sha>},
+#             {name: DISENTANGLED_RNNS_REF, value: <sha>}]
 set -euo pipefail
 
 WRAPPER_REF="${WRAPPER_REF:-main}"
 DISPATCHER_REF="${DISPATCHER_REF:-main}"
 FORAGING_MODELS_REF="${FORAGING_MODELS_REF:-main}"
+DISENTANGLED_RNNS_REF="${DISENTANGLED_RNNS_REF:-main}"
 
 refresh() {  # <repo dir> <ref> <commit env var>
     local dir="$1" ref="$2" commit_env="$3" commit
@@ -39,6 +41,7 @@ refresh() {  # <repo dir> <ref> <commit env var>
 echo "[entrypoint] refreshing source from GitHub before the run..."
 refresh /workspace/aind-disrnn-dispatcher          "$DISPATCHER_REF"       DISPATCHER_COMMIT
 refresh /workspace/aind-dynamic-foraging-models    "$FORAGING_MODELS_REF"  FORAGING_MODELS_COMMIT
+refresh /workspace/aind-disentangled-rnns          "$DISENTANGLED_RNNS_REF" DISENTANGLED_RNNS_COMMIT
 refresh /workspace/aind-disrnn-wrapper             "$WRAPPER_REF"          WRAPPER_COMMIT
 
 if [ "$#" -eq 0 ]; then

--- a/beaker/smoke.yaml
+++ b/beaker/smoke.yaml
@@ -28,6 +28,7 @@ tasks:
         set -e
         python -c "import jax; print('JAX devices:', jax.devices())"
         python -c "import aind_dynamic_foraging_models; print('foraging models import: OK')"
+        python -c "import disentangled_rnns; print('disentangled RNNs import: OK')"
         python -m run_hpc --cfg job data=synthetic model=disrnn
         echo "SMOKE OK"
     context:
@@ -44,6 +45,8 @@ tasks:
       - name: DISPATCHER_REF
         value: main
       - name: FORAGING_MODELS_REF
+        value: main
+      - name: DISENTANGLED_RNNS_REF
         value: main
     result:
       path: /results

--- a/beaker/smoke.yaml
+++ b/beaker/smoke.yaml
@@ -8,7 +8,7 @@
 ##      dependency) via `run_hpc --cfg job`, which prints the resolved config
 ##      and exits — no training, no W&B.
 ##
-## Fill <username> (from `beaker image get disrnn-wrapper`), then submit:
+## Submit:
 ##   beaker experiment create \
 ##     -w ai1/aind-dynamic-foraging-foundation-model beaker/smoke.yaml
 ## Watch it:  https://beaker.org/ex/<experiment-id>   (look for "SMOKE OK")
@@ -18,7 +18,7 @@ description: disRNN image smoke test (GPU + imports + Hydra config, no W&B)
 tasks:
   - name: smoke
     image:
-      beaker: han-hou/disrnn-wrapper
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh

--- a/beaker/smoke.yaml
+++ b/beaker/smoke.yaml
@@ -2,7 +2,7 @@
 ## WITHOUT W&B, a sweep, or any real training.
 ##
 ## It checks, in one short job:
-##   1. image pulls + beaker/entrypoint.sh runs its runtime git-pull
+##   1. image pulls + beaker/entrypoint.sh refreshes all runtime repos
 ##   2. JAX sees the GPU (jax.devices())
 ##   3. Hydra composes the config across BOTH repos (the sibling-layout
 ##      dependency) via `run_hpc --cfg job`, which prints the resolved config
@@ -27,6 +27,7 @@ tasks:
       - |
         set -e
         python -c "import jax; print('JAX devices:', jax.devices())"
+        python -c "import aind_dynamic_foraging_models; print('foraging models import: OK')"
         python -m run_hpc --cfg job data=synthetic model=disrnn
         echo "SMOKE OK"
     context:
@@ -39,8 +40,10 @@ tasks:
       gpuCount: 1
     envVars:
       - name: WRAPPER_REF
-        value: ai_hub
+        value: main
       - name: DISPATCHER_REF
-        value: ai_hub
+        value: main
+      - name: FORAGING_MODELS_REF
+        value: main
     result:
       path: /results

--- a/beaker/smoke.yaml
+++ b/beaker/smoke.yaml
@@ -28,7 +28,6 @@ tasks:
         set -e
         python -c "import jax; print('JAX devices:', jax.devices())"
         python -c "import aind_dynamic_foraging_models; print('foraging models import: OK')"
-        python -c "import disentangled_rnns; print('disentangled RNNs import: OK')"
         python -m run_hpc --cfg job data=synthetic model=disrnn
         echo "SMOKE OK"
     context:
@@ -45,8 +44,6 @@ tasks:
       - name: DISPATCHER_REF
         value: main
       - name: FORAGING_MODELS_REF
-        value: main
-      - name: DISENTANGLED_RNNS_REF
         value: main
     result:
       path: /results

--- a/code/tests/test_run_helpers.py
+++ b/code/tests/test_run_helpers.py
@@ -34,6 +34,7 @@ class TestRunHelpers(unittest.TestCase):
             "WRAPPER_COMMIT": "wrapper-sha",
             "DISPATCHER_COMMIT": "dispatcher-sha",
             "FORAGING_MODELS_COMMIT": "foraging-models-sha",
+            "DISENTANGLED_RNNS_COMMIT": "disentangled-rnns-sha",
         }
 
         with mock.patch.dict(os.environ, commits, clear=False):
@@ -43,6 +44,9 @@ class TestRunHelpers(unittest.TestCase):
         self.assertEqual(versions["dispatcher_commit"], "dispatcher-sha")
         self.assertEqual(
             versions["foraging_models_commit"], "foraging-models-sha"
+        )
+        self.assertEqual(
+            versions["disentangled_rnns_commit"], "disentangled-rnns-sha"
         )
 
     def test_resolve_disrnn_penalties_uses_beta_as_default_base(self):

--- a/code/tests/test_run_helpers.py
+++ b/code/tests/test_run_helpers.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import os
 import unittest
+from unittest import mock
 
 try:
     from omegaconf import OmegaConf
 
     from utils.run_helpers import (
+        _code_versions,
         apply_dynamic_run_name_components,
         apply_model_penalty_multipliers,
         resolve_disrnn_penalties,
@@ -26,6 +29,22 @@ except ModuleNotFoundError as exc:
     f"run helper dependencies unavailable: {RUN_HELPERS_IMPORT_ERROR}",
 )
 class TestRunHelpers(unittest.TestCase):
+    def test_code_versions_prefers_all_runtime_commit_env_vars(self):
+        commits = {
+            "WRAPPER_COMMIT": "wrapper-sha",
+            "DISPATCHER_COMMIT": "dispatcher-sha",
+            "FORAGING_MODELS_COMMIT": "foraging-models-sha",
+        }
+
+        with mock.patch.dict(os.environ, commits, clear=False):
+            versions = _code_versions()
+
+        self.assertEqual(versions["wrapper_commit"], "wrapper-sha")
+        self.assertEqual(versions["dispatcher_commit"], "dispatcher-sha")
+        self.assertEqual(
+            versions["foraging_models_commit"], "foraging-models-sha"
+        )
+
     def test_resolve_disrnn_penalties_uses_beta_as_default_base(self):
         resolved = resolve_disrnn_penalties(
             {

--- a/code/tests/test_run_helpers.py
+++ b/code/tests/test_run_helpers.py
@@ -34,7 +34,6 @@ class TestRunHelpers(unittest.TestCase):
             "WRAPPER_COMMIT": "wrapper-sha",
             "DISPATCHER_COMMIT": "dispatcher-sha",
             "FORAGING_MODELS_COMMIT": "foraging-models-sha",
-            "DISENTANGLED_RNNS_COMMIT": "disentangled-rnns-sha",
         }
 
         with mock.patch.dict(os.environ, commits, clear=False):
@@ -44,9 +43,6 @@ class TestRunHelpers(unittest.TestCase):
         self.assertEqual(versions["dispatcher_commit"], "dispatcher-sha")
         self.assertEqual(
             versions["foraging_models_commit"], "foraging-models-sha"
-        )
-        self.assertEqual(
-            versions["disentangled_rnns_commit"], "disentangled-rnns-sha"
         )
 
     def test_resolve_disrnn_penalties_uses_beta_as_default_base(self):

--- a/code/utils/run_helpers.py
+++ b/code/utils/run_helpers.py
@@ -229,11 +229,15 @@ def _code_versions() -> dict[str, Optional[str]]:
     wrapper_dir = Path(__file__).resolve().parents[2]  # .../aind-disrnn-wrapper
     dispatcher_dir = wrapper_dir.parent / "aind-disrnn-dispatcher"
     foraging_models_dir = wrapper_dir.parent / "aind-dynamic-foraging-models"
+    disentangled_rnns_dir = wrapper_dir.parent / "aind-disentangled-rnns"
     return {
         "wrapper_commit": sha(wrapper_dir, "WRAPPER_COMMIT"),
         "dispatcher_commit": sha(dispatcher_dir, "DISPATCHER_COMMIT"),
         "foraging_models_commit": sha(
             foraging_models_dir, "FORAGING_MODELS_COMMIT"
+        ),
+        "disentangled_rnns_commit": sha(
+            disentangled_rnns_dir, "DISENTANGLED_RNNS_COMMIT"
         ),
     }
 

--- a/code/utils/run_helpers.py
+++ b/code/utils/run_helpers.py
@@ -229,15 +229,11 @@ def _code_versions() -> dict[str, Optional[str]]:
     wrapper_dir = Path(__file__).resolve().parents[2]  # .../aind-disrnn-wrapper
     dispatcher_dir = wrapper_dir.parent / "aind-disrnn-dispatcher"
     foraging_models_dir = wrapper_dir.parent / "aind-dynamic-foraging-models"
-    disentangled_rnns_dir = wrapper_dir.parent / "aind-disentangled-rnns"
     return {
         "wrapper_commit": sha(wrapper_dir, "WRAPPER_COMMIT"),
         "dispatcher_commit": sha(dispatcher_dir, "DISPATCHER_COMMIT"),
         "foraging_models_commit": sha(
             foraging_models_dir, "FORAGING_MODELS_COMMIT"
-        ),
-        "disentangled_rnns_commit": sha(
-            disentangled_rnns_dir, "DISENTANGLED_RNNS_COMMIT"
         ),
     }
 

--- a/code/utils/run_helpers.py
+++ b/code/utils/run_helpers.py
@@ -203,12 +203,11 @@ def _hardware_tags() -> list[str]:
 
 
 def _code_versions() -> dict[str, Optional[str]]:
-    """Resolved commit SHAs of the wrapper + dispatcher repos, for reproducibility.
+    """Resolved commit SHAs of the runtime source repos, for reproducibility.
 
     Stamped into the W&B run config so every run is traceable to the exact code it
-    ran. Prefers the WRAPPER_COMMIT / DISPATCHER_COMMIT env vars (e.g. set by
-    beaker/entrypoint.sh) and falls back to `git rev-parse` on the on-disk repos;
-    None if neither is available (so it's harmless on any platform).
+    ran. Prefers commit env vars set by ``beaker/entrypoint.sh`` and falls back
+    to ``git rev-parse`` on the on-disk repos; None if neither is available.
     """
 
     def sha(repo_dir: Path, env_var: str) -> Optional[str]:
@@ -229,9 +228,13 @@ def _code_versions() -> dict[str, Optional[str]]:
 
     wrapper_dir = Path(__file__).resolve().parents[2]  # .../aind-disrnn-wrapper
     dispatcher_dir = wrapper_dir.parent / "aind-disrnn-dispatcher"
+    foraging_models_dir = wrapper_dir.parent / "aind-dynamic-foraging-models"
     return {
         "wrapper_commit": sha(wrapper_dir, "WRAPPER_COMMIT"),
         "dispatcher_commit": sha(dispatcher_dir, "DISPATCHER_COMMIT"),
+        "foraging_models_commit": sha(
+            foraging_models_dir, "FORAGING_MODELS_COMMIT"
+        ),
     }
 
 


### PR DESCRIPTION
## Summary
- default wrapper, dispatcher, and foraging-models refs to `main`
- refresh `aind-dynamic-foraging-models` from GitHub at container startup and record its resolved commit in run provenance
- keep `aind-disentangled-rnns` pinned and image-baked to avoid runtime JAX installation
- add the Beaker image build log and update the current image to `han-hou/disrnn-wrapper-main-20260712`

## Validation
- shell syntax and smoke YAML validation
- targeted provenance unit tests (self-skipped locally because JAX/Haiku are unavailable)
- Beaker GPU smoke: https://beaker.org/ex/01KXCGK6MM6QV3AND8C7ZC1TCX