### PR TITLE
perf(disrnn): stop rebuilding the whole-cohort frame at every checkpoint (~5 h/run at D=614)

### DIFF
--- a/code/model_trainers/disrnn_trainer.py
+++ b/code/model_trainers/disrnn_trainer.py
@@ -1714,19 +1714,21 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
                     )
                 )
                 if should_plot_split_examples_ckpt or should_save_output_df_ckpt:
-                    yhat_full_ckpt, network_states_full_ckpt = rnn_utils.eval_network(
+                    yhat_full_ckpt, network_states_full_ckpt = self._eval_network_full(
                         current_noiseless_eval_network,
                         params,
                         xs_full_for_checkpoint,
                     )
-                    output_df_ckpt = dl.add_model_results(
-                        df_for_checkpoint.copy(),
-                        np.asarray(network_states_full_ckpt),
-                        yhat_full_ckpt,
-                        ignore_policy=ignore_policy,
-                    )
-
+                    # Only build the whole-cohort frame when it is persisted;
+                    # plotting builds per-subject frames on demand below.
+                    output_df_ckpt = None
                     if should_save_output_df_ckpt:
+                        output_df_ckpt = dl.add_model_results(
+                            df_for_checkpoint.copy(),
+                            np.asarray(network_states_full_ckpt),
+                            np.asarray(yhat_full_ckpt),
+                            ignore_policy=ignore_policy,
+                        )
                         output_df_ckpt_path = checkpoint_dir / "output_df.csv"
                         output_df_ckpt.to_csv(output_df_ckpt_path, index=False)
                         checkpoint_record["output_df_path"] = str(output_df_ckpt_path)
@@ -1734,12 +1736,14 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
                     if should_plot_split_examples_ckpt:
                         n_action_logits_ckpt_full = _require_n_action_logits(
                             dataset_eval,
-                            yhat_full_ckpt,
+                            np.asarray(yhat_full_ckpt),
                             context="checkpoint full-dataset plotting",
                         )
                         split_summaries_ckpt = self._generate_split_examples(
                             output_dir=checkpoint_dir,
                             output_df=output_df_ckpt,
+                            raw_df=df_for_checkpoint,
+                            ignore_policy=ignore_policy,
                             network_states_full=np.asarray(network_states_full_ckpt),
                             yhat_full=np.asarray(yhat_full_ckpt),
                             params=params,

--- a/code/tests/test_disrnn_trainer.py
+++ b/code/tests/test_disrnn_trainer.py
@@ -292,6 +292,127 @@ class TestDisrnnTrainer(unittest.TestCase):
         self.assertLessEqual(output["likelihood_train"], 1.0)
         self.assertTrue((self.output_dir / "checkpoints" / "index.json").exists())
 
+    def _checkpoint_plotting_trainer(self, **training_overrides):
+        training = {
+            "lr": 1e-3,
+            "n_steps": 4,
+            "n_warmup_steps": 1,
+            "loss": "penalized_categorical",
+            "loss_param": 1.0,
+            "max_grad_norm": 1.0,
+            "checkpoint_every_n_steps": 2,
+            "checkpoint_plot_split_examples_every_n": 2,  # plotting ON at every checkpoint
+            "checkpoint_save_output_df_every_n": 0,  # whole-cohort frame NOT persisted
+            "checkpoint_log_eval_to_wandb": False,
+            "checkpoint_log_train_to_wandb": False,
+            "checkpoint_log_split_examples_to_wandb": False,
+            "checkpoint_run_heldout_eval": False,
+            "checkpoint_plot_choice_rule": False,
+            "checkpoint_plot_update_rules": False,
+            "plot_choice_rule": False,
+            "plot_update_rules": False,
+            "save_output_df": False,
+        }
+        training.update(training_overrides)
+        return DisrnnTrainer(
+            architecture={
+                "multisubject": True,
+                "latent_size": 4,
+                "update_net_n_units_per_layer": 8,
+                "update_net_n_layers": 2,
+                "choice_net_n_units_per_layer": 4,
+                "choice_net_n_layers": 1,
+                "activation": "leaky_relu",
+                "subject_embedding_size": 3,
+            },
+            penalties={
+                "latent_penalty": 1e-3,
+                "choice_net_latent_penalty": 1e-3,
+                "update_net_obs_penalty": 1e-3,
+                "update_net_latent_penalty": 1e-3,
+                "subject_penalty": 1e-3,
+                "update_net_subject_penalty": 1e-3,
+                "choice_net_subject_penalty": 1e-3,
+            },
+            training=training,
+            output_dir=str(self.output_dir),
+            seed=42,
+        )
+
+    def test_checkpoint_plotting_does_not_materialize_whole_cohort_frame(self):
+        """Checkpoint example-plotting must NOT build the whole-cohort per-trial
+        frame when it is not being persisted.
+
+        Only a couple of subjects are ever plotted, but the checkpoint used to
+        call `dl.add_model_results` over the ENTIRE cohort on every checkpoint --
+        purely to feed those few plots. At D=614 that cost ~50 min per checkpoint
+        (~5 h per run). `gru_trainer` already avoids this by passing `raw_df` and
+        leaving `output_df=None` so each split's frame is built on demand; this
+        test pins the same contract for the disRNN.
+        """
+        trainer = self._checkpoint_plotting_trainer()
+        bundle = self._make_multisubject_bundle()
+        whole_cohort_rows = len(bundle.raw)
+
+        seen_kwargs = []
+        real = BaseMultisubjectTrainer._generate_split_examples
+
+        def spy(self, **kwargs):
+            seen_kwargs.append(kwargs)
+            return real(self, **kwargs)
+
+        # Record the SIZE of every frame handed to add_model_results. The lazy path
+        # still calls it -- more often, in fact -- but on small per-split slices, so
+        # the CALL COUNT is not the signal. The number of WHOLE-COHORT frames is.
+        frame_rows = []
+        real_add = dl.add_model_results
+
+        def add_spy(raw_df, *args, **kwargs):
+            frame_rows.append(len(raw_df))
+            return real_add(raw_df, *args, **kwargs)
+
+        with patch.object(BaseMultisubjectTrainer, "_generate_split_examples", spy), \
+                patch.object(dl, "add_model_results", add_spy):
+            trainer.fit(bundle)
+
+        # PRIMARY CONTRACT: building the whole-cohort per-trial frame is what cost
+        # ~50 min per checkpoint at D=614. It is still built ONCE at the end of
+        # training (the final eval legitimately needs it), but must never be built
+        # inside the checkpoint loop.
+        whole_cohort_builds = [n for n in frame_rows if n == whole_cohort_rows]
+        self.assertLessEqual(
+            len(whole_cohort_builds),
+            1,
+            f"the whole-cohort frame ({whole_cohort_rows} rows) was built "
+            f"{len(whole_cohort_builds)}x; it must be built at most once (the final "
+            f"eval) and never per checkpoint. Frame sizes seen: {frame_rows}",
+        )
+
+        # And the mechanism that makes that possible: checkpoint plotting is handed
+        # raw_df and slices per-subject frames on demand, rather than a prebuilt
+        # whole-cohort output_df.
+        checkpoint_calls = [
+            kw for kw in seen_kwargs if kw.get("wandb_key_prefix") == "checkpoint"
+        ]
+        self.assertTrue(checkpoint_calls, "expected checkpoint plotting to run")
+        for kwargs in checkpoint_calls:
+            self.assertIsNone(kwargs.get("output_df"))
+            self.assertIsNotNone(kwargs.get("raw_df"))
+            self.assertIsNotNone(kwargs.get("ignore_policy"))
+
+    def test_checkpoint_still_persists_output_df_when_requested(self):
+        """The lazy-frame optimization must not break the persist path: when
+        checkpoint_save_output_df_every_n > 0 the whole-cohort frame is still
+        built and written to disk."""
+        trainer = self._checkpoint_plotting_trainer(checkpoint_save_output_df_every_n=2)
+
+        output = trainer.fit(self._make_multisubject_bundle())
+
+        self.assertTrue(output["checkpoints"])
+        for checkpoint in output["checkpoints"]:
+            self.assertIn("output_df_path", checkpoint)
+            self.assertTrue(Path(checkpoint["output_df_path"]).exists())
+
     def test_resume_from_checkpoint_matches_uninterrupted(self):
         """End-to-end resume: a run interrupted at a checkpoint and relaunched
         reproduces the uninterrupted run's final params exactly (optimizer +


### PR DESCRIPTION
## The problem

At **every checkpoint**, `disrnn_trainer` ran a full-dataset forward pass retaining all hidden states, then built the **whole-cohort per-trial DataFrame** (`dl.add_model_results`) — **solely to plot example sessions for 2 subjects** (`"Limiting example plotting to first 2 subjects (of 614 total)"`).

Measured on a full-cohort (D=614) run, from the job log — one step-2000 checkpoint:

```
09:55:07  Checkpoint step 2000, eval likelihood: 0.7239
10:48:45  Checkpoint step 2000, training open latents ...   <- 53 minutes later
```

That is **~50 min per checkpoint**. With `checkpoint_every_n_steps=10000` over a 60k-step run, it adds **~5 h on top of ~16.7 h of training** — i.e. a 60k-step D=614 disRNN run costs ~22 h instead of ~18 h, and the overhead scales with cohort size.

## The cause

`gru_trainer` **already avoids this**:

```python
# Only build the whole-cohort frame when it is persisted;
# plotting builds per-subject frames on demand below.
output_df_ckpt = None
if should_save_output_df_ckpt:
    output_df_ckpt = add_gru_model_results(...)
```

…and it passes `raw_df` so `_generate_split_examples` slices a small per-subject frame on demand (`base_multisubject_trainer.py:937`). The base class even documents the contract:

> *"Only a handful of subjects are ever plotted, so a caller can avoid materializing the whole-cohort per-trial frame (the eval OOM at scale) by passing `raw_df` (+ `ignore_policy`) and leaving `output_df=None`"*

**The optimization was never ported to disRNN.** `disrnn_trainer` built the frame unconditionally — even though `checkpoint_save_output_df_every_n=0` by default, so it was never even written to disk.

## The fix

A verbatim port of the GRU pattern:

- `output_df_ckpt = None` unless `checkpoint_save_output_df_every_n` fires — the whole-cohort frame is built **only when it is actually persisted**.
- Pass `raw_df` + `ignore_policy` to `_generate_split_examples`, so plotting builds small per-split frames itself.
- Route the forward pass through `self._eval_network_full` (the shared helper GRU uses) instead of `rnn_utils.eval_network`. **Behaviour-identical today** — disRNN doesn't set `_eval_max_episodes`, so it remains a single call — but it puts both trainers on one code path.

**Metrics are untouched.** Checkpoint train/eval likelihoods are computed in a separate block this PR does not modify, and the end-of-training eval still builds the full frame (it legitimately needs it).

## Verification

Both directions, on a compute node:

| | whole-cohort frames built | result |
|---|---|---|
| **old code** | **3×** (2 checkpoints + final) — sizes `[400, 200, 400, 200, 600, 600, 600]` | test **FAILS** |
| **with fix** | **1×** (final eval only) | both tests **pass** |

Two tests:

- `test_checkpoint_plotting_does_not_materialize_whole_cohort_frame` — spies on the **size** of every frame handed to `add_model_results` and asserts a whole-cohort frame is built at most once, never per checkpoint. Note the **call count is deliberately not the assertion**: the lazy path calls `add_model_results` *more* times (once per plotted split), just on tiny slices — counting calls measures the wrong thing.
- `test_checkpoint_still_persists_output_df_when_requested` — guards the other branch, so the optimization can't silently break `output_df` persistence.

## Pre-existing failures (not touched)

`test_disrnn_trainer` has **3 failures on a clean `origin/main` checkout**, unrelated to this change and failing identically without it:

- `test_multisubject_model_rejects_unknown_subject_embedding_init`
- `test_multisubject_session_conditioning_reduces_obs_size`
- `test_multisubject_session_conditioning_uses_trailing_observation_names`

All concern subject-embedding init / session-conditioning observation naming. Flagged, not absorbed.

## Impact

Does **not** affect the in-flight `05-disrnn-scaling-law` grid (those 27 tasks are pinned to their source SHAs), so no restart is needed. Future disRNN runs at large cohort get ~5 h/run back, and the win grows with D.

## Follow-up (deliberately out of scope)

disRNN doesn't set `_eval_max_episodes`, so its full-dataset forward pass is unchunked — GRU caps it at 4096 episodes to avoid OOM at scale (the OOM churn study 03 hit). Worth a separate PR; it changes shared base-class eval paths and is a memory fix, not a speed fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127mCUQkekGsRtNEQPXRSw3