### PR TITLE
feat(stage4b-recovery): emit position-R² mechanism diagnostic in-container

### DIFF
--- a/code/analysis/stage4b_recovery.py
+++ b/code/analysis/stage4b_recovery.py
@@ -118,6 +118,17 @@ for run, meta in inv.items():
             out["persession_confusion_sessioncond"] = confusion_matrix(y, yhat_sess, labels=labs).tolist()
             out["persession_labels"] = labs
             out["n_session_rows"] = int(len(m))
+            # Mechanism diagnostic: how much smooth session POSITION does the
+            # session-conditioned embedding encode? High position-R^2 alongside a ~0
+            # per-session family gap shows the session code is a POSITION code (good for
+            # Stage-2 drift), structurally unable to represent a discrete regime draw.
+            # subject-only is the ~0 control (constant within subject).
+            if "session_phase" in m.columns:
+                pos = m["session_phase"].values
+                out["position_r2_sessioncond"] = float(r2_score(
+                    pos, cross_val_predict(LinearRegression(), Xsess, pos, cv=gkf, groups=groups)))
+                out["position_r2_subjectonly"] = float(r2_score(
+                    pos, cross_val_predict(LinearRegression(), Xsubj, pos, cv=gkf, groups=groups)))
             m.to_csv(os.path.join(outdir, f"ctx_{run}.csv"), index=False)
 
         # save per-subject embedding + mixweights for figures
@@ -130,7 +141,8 @@ for run, meta in inv.items():
         results[run] = out
         print(f"{run} {enc}/D{emb}: mix_R2_mean={mix_r2_mean:.3f} dom_acc={dom_acc} "
               f"sess_fam={out.get('persession_family_acc_sessioncond')} "
-              f"subj_fam={out.get('persession_family_acc_subjectonly')}", flush=True)
+              f"subj_fam={out.get('persession_family_acc_subjectonly')} "
+              f"pos_R2={out.get('position_r2_sessioncond')}", flush=True)
     except Exception as ex:
         import traceback; print(f"{run} FAILED: {type(ex).__name__}: {ex}", flush=True)
         traceback.print_exc()


### PR DESCRIPTION
## What
Adds the **position-R²** mechanism diagnostic to `code/analysis/stage4b_recovery.py`, emitted in the recovery JSON for scalar (session-conditioned) runs:
- `position_r2_sessioncond` — R² of predicting session position (`session_phase`) from the session-conditioned embedding, GroupKFold by subject.
- `position_r2_subjectonly` — the ~0 control (subject embedding is constant within subject).

## Why
The Stage-4b concentration result (dispatcher `studies/04` **r3**) hinges on: the session-conditioned embedding encodes smooth session **position** (R²≈0.6) but **not** the discrete per-session family (gap≈0) — a continuous position code can't represent a discrete regime draw. That diagnostic was computed post-hoc from the `ctx_*.csv` artifacts; emitting it in-container makes the report **one-step reproducible** from the recovery JSON alone.

## How
Reuses the already-built ctx dataframe, `groups`, and `Xsess/Xsubj`, plus the already-imported `LinearRegression`/`r2_score` — **no new deps, no extra data loading**. Guarded on the `session_phase` column, so older runs without it are unaffected. Takes effect on the next recovery run.

Syntax-checked (`py_compile`); full pytest not run here (training stack not installable in the launch sandbox; §5 keeps heavy work off the login node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WReHDhDFAfXXDN7Jxh8Grm