### PR TITLE
fix(disrnn): stop a diagnostic plot from killing training at wide embeddings

### DIFF
--- a/code/model_trainers/base_multisubject_trainer.py
+++ b/code/model_trainers/base_multisubject_trainer.py
@@ -42,6 +42,11 @@ from utils.multisubject import (
 
 logger = logging.getLogger(__name__)
 
+# Cap on how many embedding dims the subject-embedding state-space plot pairs up. The panel grid
+# is O(dim^2), so an uncapped 64-dim embedding produces a 554 MP figure that PIL rejects as a
+# decompression bomb. 6 dims = C(6,2) = 15 panels.
+_EMBEDDING_PLOT_MAX_DIMS = 6
+
 
 def _to_dict(config: Mapping[str, Any] | DictConfig) -> Dict[str, Any]:
     if isinstance(config, DictConfig):
@@ -341,6 +346,12 @@ class BaseMultisubjectTrainer(ModelTrainer):
             for column in plot_df.columns
             if column.startswith("embedding_")
         ]
+        # The panel grid is every PAIR of embedding dims, so its area grows as O(dim^2) with no
+        # cap: a 64-dim embedding gives C(64,2)=2016 pairs -> 672 rows -> a 1650 x 336,000 px
+        # figure (554 MP), which PIL refuses as a decompression bomb and which killed the run.
+        # Plot only the leading dims: C(6,2)=15 pairs is already more than anyone reads, and the
+        # figure stays bounded no matter how wide the embedding is.
+        embedding_columns = embedding_columns[:_EMBEDDING_PLOT_MAX_DIMS]
         dim_pairs = list(itertools.combinations(embedding_columns, 2))
         if not dim_pairs:
             return None

--- a/code/model_trainers/disrnn_trainer.py
+++ b/code/model_trainers/disrnn_trainer.py
@@ -666,27 +666,39 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
             logger.warning("Initialization plotting failed for %s: %s", stage_name, exc)
 
         if wandb_run is not None:
+            # Building the W&B images is part of DIAGNOSTIC PLOTTING and must never be able to kill
+            # training. The plotting above is already guarded, but these wandb.Image() calls were
+            # not -- and PIL raises DecompressionBombError while OPENING an oversized figure, so a
+            # cosmetic plot took down six 18-hour runs (subject_embedding_size=64 -> a 554 MP
+            # state-space figure). Guard each conversion: a figure we cannot log is a warning, not
+            # a failed run. Metrics are unaffected -- the bottleneck numbers
+            # (final/bottlenecks/*_total_openness) come from params, not from these figures.
             plot_payload = {}
+
+            def _add_image(key: str, path: Any) -> None:
+                try:
+                    plot_payload[key] = wandb.Image(str(path))
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "Skipping W&B image %s for %s (%s): %s", key, stage_name, path, exc
+                    )
+
             if plot_paths["bottlenecks"]:
-                plot_payload["checkpoint/fig/bottlenecks"] = wandb.Image(
-                    str(plot_paths["bottlenecks"])
-                )
+                _add_image("checkpoint/fig/bottlenecks", plot_paths["bottlenecks"])
             if plot_paths["subject_embedding_state_space"]:
-                plot_payload["checkpoint/fig/subject_embedding_state_space"] = wandb.Image(
-                    str(plot_paths["subject_embedding_state_space"])
+                _add_image(
+                    "checkpoint/fig/subject_embedding_state_space",
+                    plot_paths["subject_embedding_state_space"],
                 )
             if plot_paths["subject_session_context_state_space"]:
-                plot_payload["checkpoint/fig/subject_session_context_state_space"] = (
-                    wandb.Image(str(plot_paths["subject_session_context_state_space"]))
+                _add_image(
+                    "checkpoint/fig/subject_session_context_state_space",
+                    plot_paths["subject_session_context_state_space"],
                 )
             if plot_paths["choice_rule"]:
-                plot_payload["checkpoint/fig/choice_rule"] = wandb.Image(
-                    str(plot_paths["choice_rule"])
-                )
+                _add_image("checkpoint/fig/choice_rule", plot_paths["choice_rule"])
             for index, update_rule_path in enumerate(plot_paths["update_rules"]):
-                plot_payload[f"checkpoint/fig/update_rule_{index}"] = wandb.Image(
-                    str(update_rule_path)
-                )
+                _add_image(f"checkpoint/fig/update_rule_{index}", update_rule_path)
             if plot_payload:
                 if wandb_step is None:
                     wandb_run.log(plot_payload)


### PR DESCRIPTION
## What happened

Six 18-hour training runs (`subject_embedding_size=64`) died ~11 minutes in, all with the same error:

```
PIL.Image.DecompressionBombError: Image size (554400000 pixels) exceeds limit of
178956970 pixels, could be decompression bomb DOS attack.
```

Training was fine — data loaded, shapes correct. It was killed **while rendering a diagnostic figure**.

## Two defects

**1. The subject-embedding state-space plot is O(dim²) with no cap.** It pairs up *every* combination of embedding dims:

```python
dim_pairs = list(itertools.combinations(embedding_columns, 2))   # C(64,2) = 2016
ncols = min(3, len(dim_pairs));  nrows = ceil(2016/3) = 672
figsize = (5.5*3, 5.0*672)   # 16.5 × 3360 in → 1650 × 336,000 px = 554.4 MP
```

That is **exactly** the 554,400,000 px PIL reported. Capping at the leading 6 dims (`C(6,2)` = 15 panels) bounds the figure at any embedding width:

| dim | old | new |
|---|---|---|
| 4 | 1,650,000 px | 1,650,000 px *(unchanged)* |
| 16 | 33,000,000 px | 4,125,000 px |
| 64 | **554,400,000 px** 💥 | 4,125,000 px |

Note `dim=16` was *already* generating a wasteful 33 MP figure — it only survived by sitting under PIL's limit. Every prior study used `dim≤4`, so their output is byte-identical.

**2. The dangerous one: `wandb.Image()` sat OUTSIDE the try/except that guards plotting.** The plotting block already had `except Exception → logger.warning`, but PIL raises while *opening* the file in `wandb.Image()`, one block later. So a **cosmetic diagnostic took down six real training runs**. Each conversion is now guarded: a figure we can't log is a warning, not a dead run.

**Metrics are unaffected either way** — the bottleneck numbers (`final/bottlenecks/*_total_openness`) are computed from `params`, never from these figures.

## Verification

The geometry is reproduced exactly, old vs new (see table above): the old path lands on 554,400,000 px at dim=64 — matching the traceback to the digit — and the new path is bounded at 4.1 MP for any width, with dim≤4 output unchanged.

**Test gap, stated honestly:** I have not added a unit test. Exercising `_plot_subject_embedding_state_space` end-to-end needs a full trainer + multisubject bundle fixture, and six science runs were blocked on this. The arithmetic above is a direct verification of the failing quantity, and the try/except is defensive-only. A fixture-based test asserting the panel-count cap is worth adding as a follow-up.

## Found by

`studies/05-disrnn-scaling-law/variants/subject-capacity`, which sweeps `subject_embedding_size ∈ {4,16,64}` to test whether per-subject capacity is what caps the disRNN's held-out transfer. The 4 and 16 cells ran fine; all six 64-dim cells died deterministically. Those six have been relaunched pinned to this branch's SHA (same `WANDB_RUN_ID`/group, so the grid stays one logical launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127mCUQkekGsRtNEQPXRSw3