### PR TITLE
refactor(posthoc): hydrate a model_dir from a W&B run id (and un-hardcode "gru")

### DIFF
--- a/code/post_training_analysis/wandb_model_dir.py
+++ b/code/post_training_analysis/wandb_model_dir.py
@@ -1,0 +1,176 @@
+"""Materialise a runnable ``model_dir`` from a finished W&B run.
+
+Every post-hoc analysis (`run_analysis generative`, `embedding`, held-out re-scoring, …)
+needs the same thing: a directory holding ``inputs.yaml`` + ``outputs/checkpoints/`` that
+``resolve_model_run`` can open. There are two ways to get one:
+
+  * **Beaker result dataset** — mount the source task's dataset at ``/prior``. This is what
+    ``launch_generative.py`` did. It identifies runs by enumerating Beaker *jobs*, which is a
+    lossy proxy for "the grid": an experiment carries a replacement job for every preemption
+    and every failed start, and a recovery re-submit lives in its own experiment. Both mistakes
+    are silent.
+  * **W&B run id** (this module) — the run id IS the provenance anchor, `group` + `state` is an
+    exact description of the grid, and the artifact outlives the Beaker dataset.
+
+This module is the second path, factored out of ``resume_heldout_beaker.py`` so any analysis can
+use it. It preserves that tool's two hard-won details:
+
+  1. ``inputs.yaml`` is NOT in the training-output artifact and must be reconstructed from the
+     run config (``resolve_model_run`` needs the data+model blocks to rebuild the network and
+     the reserved held-out set).
+  2. ``checkpoints/index.json`` records each ``params_path`` as the ORIGINAL ABSOLUTE path.
+     ``resolve_model_run`` remaps such a path by splitting on the FIRST ``/outputs/`` — and the
+     original path can contain ``/outputs/`` twice — so the remap lands on a nonexistent file and
+     **`best_eval` SILENTLY falls back to `final`**. Rewriting each entry to the relative form
+     forces the resolver down its unambiguous ``startswith("outputs/")`` branch.
+
+Fixed here vs. the original: the model type was **hardcoded to ``"gru"``**
+(``mtype = "gru"  # ... disRNN would be "disrnn"``), so the W&B path could not restore a disRNN
+run at all. It is now read from the run's own config.
+
+CLI (inside a container that can reach W&B):
+
+    python -m post_training_analysis.wandb_model_dir --run-id <rid> --dest /prior
+    # -> /prior/run/{inputs.yaml, outputs/checkpoints/...}   (prints the model_dir)
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import logging
+import os
+import urllib.request
+from pathlib import Path
+
+import wandb
+import yaml
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENTITY = "AIND-disRNN"
+
+
+def fetch_run_config(entity: str, project: str, run_id: str) -> dict:
+    """Fetch a run's config via the W&B GraphQL endpoint directly.
+
+    Avoids ``wandb.Api().run()`` — that auto-loads the run's Sweep, and the Sweep.get() query is
+    broken in the container's wandb build (raises 'Object of type Api is not JSON serializable').
+    A plain GraphQL POST for the config field sidesteps the whole run/sweep object graph.
+    """
+    key = os.environ["WANDB_API_KEY"]
+    q = ('query{project(name:"%s",entityName:"%s"){run(name:"%s"){config}}}'
+         % (project, entity, run_id))
+    body = json.dumps({"query": q}).encode()
+    auth = base64.b64encode(f"api:{key}".encode()).decode()
+    req = urllib.request.Request(
+        "https://api.wandb.ai/graphql",
+        data=body,
+        headers={"Content-Type": "application/json", "Authorization": "Basic " + auth},
+    )
+    resp = json.load(urllib.request.urlopen(req))
+    raw = resp["data"]["project"]["run"]["config"]
+    return json.loads(raw) if isinstance(raw, str) else raw
+
+
+def unwrap(d):
+    """Strip W&B config's ``{"value":..., "desc":...}`` wrappers, recursively."""
+    if isinstance(d, dict):
+        if set(d.keys()) <= {"value", "desc"} and "value" in d:
+            return unwrap(d["value"])
+        return {k: unwrap(v) for k, v in d.items()}
+    if isinstance(d, list):
+        return [unwrap(x) for x in d]
+    return d
+
+
+def _write_inputs_yaml(cfg: dict, model_dir: Path) -> str:
+    """Rebuild ``<model_dir>/inputs.yaml`` from the source run's config; return model type."""
+    cfg = unwrap(cfg)
+    for key in ("data", "model"):
+        if key not in cfg or not isinstance(cfg[key], dict):
+            raise ValueError(
+                f"Source run config is missing a nested '{key}' block; cannot reconstruct "
+                f"inputs.yaml (keys present: {sorted(cfg)[:20]})."
+            )
+    inputs = {"data": cfg["data"], "model": cfg["model"], "seed": cfg.get("seed")}
+    (model_dir / "inputs.yaml").write_text(yaml.safe_dump(inputs, sort_keys=False))
+    model_type = str(cfg["model"].get("type", "")).strip().lower()
+    logger.info("Reconstructed inputs.yaml (model.type=%s, ignore_policy=%s, seed=%s)",
+                model_type, cfg["data"].get("ignore_policy"), cfg.get("seed"))
+    return model_type
+
+
+def _normalize_index(outputs_dir: Path) -> None:
+    """Rewrite index.json params_path entries to relative form.
+
+    Without this, resolve_model_run's path remap can miss and `best_eval` silently degrades to
+    `final` — a wrong-checkpoint bug that produces plausible numbers. See module docstring.
+    """
+    index_path = outputs_dir / "checkpoints" / "index.json"
+    if not index_path.exists():
+        logger.warning("No checkpoints/index.json; best_eval selection may fall back to final.")
+        return
+    index = json.loads(index_path.read_text())
+    rewritten = 0
+    for rec in index.get("checkpoints", []) or []:
+        step = rec.get("step")
+        if step is not None:
+            rec["params_path"] = f"outputs/checkpoints/step_{step}/params.json"
+            rewritten += 1
+    index_path.write_text(json.dumps(index))
+    logger.info("Normalized %d params_path entries in index.json to relative form.", rewritten)
+
+
+def hydrate_model_dir(run_id: str, *, project: str, entity: str = DEFAULT_ENTITY,
+                      dest: str | Path, model_type: str | None = None) -> Path:
+    """Download a finished run's checkpoints and assemble a runnable model_dir.
+
+    Returns the model_dir (``<dest>/run``) — pass it straight to
+    ``run_analysis ... --model-dir``.
+
+    ``model_type`` is read from the run config unless given. It used to be hardcoded to "gru",
+    which silently broke every non-GRU restore.
+    """
+    dest = Path(dest).expanduser()
+    model_dir = dest / "run"
+    outputs_dir = model_dir / "outputs"
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+
+    # inputs.yaml first: it tells us the model type, which names the artifact.
+    cfg = fetch_run_config(entity, project, run_id)
+    cfg_model_type = _write_inputs_yaml(cfg, model_dir)
+    model_type = (model_type or cfg_model_type).strip().lower()
+    if model_type not in {"gru", "disrnn", "baseline_rl"}:
+        raise ValueError(f"Unsupported/unknown model type {model_type!r} for run {run_id}.")
+
+    artifact_ref = f"{entity}/{project}/{model_type}-output-{run_id}:latest"
+    logger.info("Downloading %s -> %s", artifact_ref, outputs_dir)
+    wandb.Api().artifact(artifact_ref, type="training-output").download(root=str(outputs_dir))
+
+    steps = sorted((outputs_dir / "checkpoints").glob("step_*"))
+    if not steps:
+        raise RuntimeError(f"No checkpoints/step_* under {outputs_dir} after download.")
+    logger.info("Downloaded %d checkpoint(s); latest=%s", len(steps), steps[-1].name)
+
+    _normalize_index(outputs_dir)
+    return model_dir
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--run-id", required=True, help="Finished W&B run id.")
+    p.add_argument("--project", required=True)
+    p.add_argument("--entity", default=DEFAULT_ENTITY)
+    p.add_argument("--dest", required=True, help="Directory to assemble under (model_dir=<dest>/run).")
+    p.add_argument("--model-type", default=None, help="Override; default reads it from the run config.")
+    args = p.parse_args()
+    model_dir = hydrate_model_dir(args.run_id, project=args.project, entity=args.entity,
+                                  dest=args.dest, model_type=args.model_type)
+    print(model_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/resume_heldout_beaker.py
+++ b/code/resume_heldout_beaker.py
@@ -79,32 +79,6 @@ def _unwrap(d):
     return d
 
 
-def _reconstruct_inputs_yaml(cfg: dict, model_dir: Path) -> None:
-    """Rebuild ``<model_dir>/inputs.yaml`` from the source run's config.
-
-    ``resolve_model_run`` requires inputs.yaml (data + model blocks) to rebuild
-    the network and the reserved held-out subject set. The training-output
-    artifact does not include it, but the W&B run config carries the full nested
-    ``data`` and ``model`` blocks. Write exactly those (+ seed) so the resolver
-    sees the same config the original training run used.
-    """
-    cfg = _unwrap(cfg)
-    for key in ("data", "model"):
-        if key not in cfg or not isinstance(cfg[key], dict):
-            raise ValueError(
-                f"Source run config is missing a nested '{key}' block; cannot "
-                f"reconstruct inputs.yaml (keys present: {sorted(cfg)[:20]})."
-            )
-    inputs = {"data": cfg["data"], "model": cfg["model"], "seed": cfg.get("seed")}
-    (model_dir / "inputs.yaml").write_text(yaml.safe_dump(inputs, sort_keys=False))
-    logger.info(
-        "Reconstructed inputs.yaml (model.type=%s, ignore_policy=%s, seed=%s)",
-        cfg["model"].get("type"),
-        cfg["data"].get("ignore_policy"),
-        cfg.get("seed"),
-    )
-
-
 def _build_finetune_config(cfg: dict, model_dir: Path) -> dict:
     """Mirror training_runner._run_auto_heldout_finetune's config, sourced from
     the run's own auto_heldout_finetune block so the held-out draw is identical.
@@ -170,49 +144,18 @@ def main() -> None:
     from post_training_analysis import run_heldout_subject_finetuning_from_config
 
     work = Path(args.work_dir).expanduser()
-    model_dir = work / args.run_id
-    outputs_dir = model_dir / "outputs"
-    outputs_dir.mkdir(parents=True, exist_ok=True)
 
-    api = wandb.Api()
+    # 1+2) Download the training-output artifact, reconstruct inputs.yaml, and normalize
+    #      checkpoints/index.json -- all of it now lives in the shared helper so any post-hoc
+    #      analysis (generative, embedding, this one) restores a run the same way. The helper
+    #      also reads the model type from the run config; this file used to hardcode
+    #      mtype = "gru", which silently broke every non-GRU restore.
+    from post_training_analysis.wandb_model_dir import hydrate_model_dir
 
-    # 1) Download the training-output artifact into <model_dir>/outputs so the
-    #    checkpoints/step_<N>/ tree lands where resolve_model_run looks.
-    mtype = "gru"  # ignore-scaling grid is all GRU; disRNN would be "disrnn"
-    artifact_ref = f"{args.entity}/{args.project}/{mtype}-output-{args.run_id}:latest"
-    logger.info("Downloading %s -> %s", artifact_ref, outputs_dir)
-    api.artifact(artifact_ref, type="training-output").download(root=str(outputs_dir))
-    steps = sorted((outputs_dir / "checkpoints").glob("step_*"))
-    if not steps:
-        raise RuntimeError(f"No checkpoints/step_* under {outputs_dir} after download.")
-    logger.info("Downloaded %d checkpoint(s); latest=%s", len(steps), steps[-1].name)
-
-    # 1b) Normalize checkpoints/index.json params_path entries to RELATIVE form.
-    #     The index records each params_path as the ORIGINAL absolute HPC path
-    #     (/allen/.../files/outputs/checkpoints/step_N/params.json). resolve_model_run's
-    #     _resolve_artifact_path remaps such a path by splitting on the FIRST "/outputs/",
-    #     but the HPC path contains "/outputs/" twice (/han.hou/outputs/disrnn AND
-    #     /files/outputs/), so the remap points at a nonexistent path and best_eval
-    #     SILENTLY falls back to `final` (step_90000) instead of the true best checkpoint.
-    #     Rewriting each params_path to "outputs/checkpoints/step_N/params.json" makes the
-    #     resolver take its unambiguous startswith("outputs/") branch -> model_dir/<that>.
-    index_path = outputs_dir / "checkpoints" / "index.json"
-    if index_path.exists():
-        index = json.loads(index_path.read_text())
-        rewritten = 0
-        for rec in index.get("checkpoints", []) or []:
-            step = rec.get("step")
-            if step is not None:
-                rec["params_path"] = f"outputs/checkpoints/step_{step}/params.json"
-                rewritten += 1
-        index_path.write_text(json.dumps(index))
-        logger.info("Normalized %d params_path entries in index.json to relative form.", rewritten)
-    else:
-        logger.warning("No checkpoints/index.json found; best_eval selection may fall back to final.")
-
-    # 2) Reconstruct inputs.yaml from the run config (via GraphQL, not api.run()).
+    model_dir = hydrate_model_dir(
+        args.run_id, project=args.project, entity=args.entity, dest=work / args.run_id,
+    )
     src_cfg = _fetch_run_config(args.entity, args.project, args.run_id)
-    _reconstruct_inputs_yaml(src_cfg, model_dir)
 
     # 3) Resume the ORIGINAL W&B run and inject held-out-only metrics into it.
     finetune_config = _build_finetune_config(src_cfg, model_dir)


### PR DESCRIPTION
## Why

Every post-hoc analysis (`run_analysis generative`, `embedding`, held-out re-scoring) needs the same input: a directory with `inputs.yaml` + `outputs/checkpoints/` that `resolve_model_run` can open. There were two ways to produce one, and we were using the worse one.

| | Beaker result dataset | W&B run id |
|---|---|---|
| how the grid is identified | enumerate Beaker **jobs** | `group` + `state` |
| preempted / failed jobs | come through as extra "tasks" | n/a |
| cells split across recovery experiments | **silently dropped** | n/a |
| durability | dataset can be GC'd | artifact persists |
| portability | Beaker only | Beaker **or** HPC |

Job enumeration is a lossy proxy for "the grid": an experiment carries a replacement job for **every preemption and every failed start**, and a recovery re-submit lives in **its own experiment**. Both failure modes are silent, and both were live in `launch_generative.py` — on a 15-cell grid it produced **17 tasks** (rolling out against a dead job's empty dataset, double-counting two cells), and with a single `--source-exp` it yielded **14 of 15**.

## …and the W&B route was broken for anything but GRU

It existed only welded inside `resume_heldout_beaker.py`, where:

```python
mtype = "gru"  # ignore-scaling grid is all GRU; disRNN would be "disrnn"
```

So restoring a **disRNN** run from W&B requested a `gru-output-<rid>` artifact and 404'd. Nobody noticed because that tool had only ever been pointed at GRU runs.

## What this does

Factors the route out into `post_training_analysis/wandb_model_dir.py`:

```python
hydrate_model_dir(run_id, project=..., dest=...) -> model_dir
# CLI: python -m post_training_analysis.wandb_model_dir --run-id <rid> --project <p> --dest /prior
```

…reading the model type **from the run's own config**, and preserving both hard-won details of the original:

1. **`inputs.yaml` is not in the artifact** and must be reconstructed from the run config — `resolve_model_run` needs the data+model blocks to rebuild the network and the reserved held-out set.
2. **`checkpoints/index.json` stores each `params_path` as an absolute path.** `resolve_model_run` remaps it by splitting on the *first* `/outputs/`, which can appear twice — so the remap misses and **`best_eval` silently falls back to `final`**. That's a wrong-checkpoint bug that produces perfectly plausible numbers. Rewriting entries to relative form forces the resolver's unambiguous branch.

`resume_heldout_beaker.py` now delegates to the helper instead of keeping its own copy; its orphaned `_reconstruct_inputs_yaml` is removed.

## Verification

End-to-end against a real disRNN run (`dscan-mult2` D=10 seed 0):

```
INFO Reconstructed inputs.yaml (model.type=disrnn, ignore_policy=exclude)
INFO Downloading AIND-disRNN/disrnn_data_scaling/disrnn-output-...:latest
INFO Downloaded 6 checkpoint(s); latest=step_60000
INFO Normalized 3 params_path entries in index.json to relative form.
```

The old hardcoded path would have 404'd on this run.

**Incidental finding worth knowing:** the checkpoint index records only the **last 3** checkpoints (40k/50k/60k here) even though 6 exist on disk — so `--checkpoint-policy best_eval` selects among those three, not all six. For study 05 that matters: our reported held-out numbers come from `final`, so the generative rollout must use `--checkpoint-policy final` or it would score a *different model* than the one we published likelihoods for.

## Consumer

`studies/05-disrnn-scaling-law` — 2nd-order generative validation of the disRNN scaling grid (the disRNN counterpart of study 01's r9), selecting its 15 cells by W&B group instead of job enumeration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127mCUQkekGsRtNEQPXRSw3