### PR TITLE
fix(disrnn): stop a cosmetic checkpoint plot from killing training; plot embedding PCs

### DIFF
--- a/code/model_trainers/base_multisubject_trainer.py
+++ b/code/model_trainers/base_multisubject_trainer.py
@@ -14,7 +14,7 @@ import itertools
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, Mapping, Sequence
+from typing import Any, Callable, Dict, Mapping, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -42,10 +42,70 @@ from utils.multisubject import (
 
 logger = logging.getLogger(__name__)
 
-# Cap on how many embedding dims the subject-embedding state-space plot pairs up. The panel grid
-# is O(dim^2), so an uncapped 64-dim embedding produces a 554 MP figure that PIL rejects as a
-# decompression bomb. 6 dims = C(6,2) = 15 panels.
-_EMBEDDING_PLOT_MAX_DIMS = 6
+# The state-space plots always show the leading _EMBEDDING_PLOT_N_PCS principal components of the
+# subject embedding, paired up: C(4,2) = 6 panels per subject, at ANY embedding width. 4 matches
+# the default subject_embedding_size, so the figure keeps the exact shape people already read.
+#
+# They used to pair up the RAW embedding dims, which is O(dim^2): subject_embedding_size=64 asks
+# for C(64,2)=2016 panels PER SUBJECT -- a 1.69 GP figure that is unreadable, and that PIL rejects
+# as a decompression bomb (it killed six training runs). Raw dims are not worth enumerating
+# anyway: the embedding is defined only up to rotation, so "dim 3 vs dim 7" carries no special
+# meaning. The PCs are rotation-invariant, use every dim, keep the panel count constant, and make
+# runs at different embedding widths directly comparable -- while pushing far fewer images to W&B.
+_EMBEDDING_PLOT_N_PCS = 4
+
+
+def _project_embedding_columns_for_plot(
+    plot_df: pd.DataFrame,
+    embedding_columns: list[str],
+) -> tuple[pd.DataFrame, list[str], Callable[[np.ndarray], np.ndarray]]:
+    """Replace the raw embedding dims with their leading principal components, for plotting.
+
+    Returns the augmented frame, the PC columns the caller should pair up, and the projection
+    itself -- callers that overlay a raw embedding vector (e.g. the subject's base embedding, as
+    a star) MUST push it through this same basis rather than indexing raw dims, or the overlay
+    lands in a different space than the points around it.
+
+    Coordinate ``i`` of a projected vector corresponds to column ``i`` of the returned columns.
+    Fewer components are returned when the data cannot support 4 (a narrow embedding, or too few
+    rows), in which case the raw columns and an identity projection are returned unchanged.
+    """
+    values = plot_df[embedding_columns].to_numpy(dtype=float)
+    n_components = min(_EMBEDDING_PLOT_N_PCS, values.shape[0], values.shape[1])
+    if n_components < 2:
+        return plot_df, embedding_columns, lambda raw: raw
+
+    mean = values.mean(axis=0, keepdims=True)
+    centered = values - mean
+    # Right singular vectors of the centered matrix are the principal axes.
+    _, singular_values, components = np.linalg.svd(centered, full_matrices=False)
+    basis = components[:n_components]
+    projected = centered @ basis.T
+
+    spectrum = np.square(singular_values)
+    total = float(spectrum.sum())
+    explained = (spectrum[:n_components] / total) if total > 0 else np.zeros(n_components)
+    logger.info(
+        "Projecting %d-dim subject embedding onto %d PCs for the state-space plot "
+        "(explained variance: %s).",
+        len(embedding_columns),
+        n_components,
+        ", ".join(
+            f"PC{index + 1} {100.0 * float(value):.1f}%"
+            for index, value in enumerate(explained)
+        ),
+    )
+
+    def project(raw: np.ndarray) -> np.ndarray:
+        """Map raw embedding coordinates into the plotted PC space (same centering + basis)."""
+        raw = np.asarray(raw, dtype=float)
+        return (raw - mean.reshape(-1)) @ basis.T
+
+    plot_df = plot_df.copy()
+    projected_columns = [f"embedding_pc{index + 1}" for index in range(n_components)]
+    for index, column in enumerate(projected_columns):
+        plot_df[column] = projected[:, index]
+    return plot_df, projected_columns, project
 
 
 def _to_dict(config: Mapping[str, Any] | DictConfig) -> Dict[str, Any]:
@@ -346,12 +406,9 @@ class BaseMultisubjectTrainer(ModelTrainer):
             for column in plot_df.columns
             if column.startswith("embedding_")
         ]
-        # The panel grid is every PAIR of embedding dims, so its area grows as O(dim^2) with no
-        # cap: a 64-dim embedding gives C(64,2)=2016 pairs -> 672 rows -> a 1650 x 336,000 px
-        # figure (554 MP), which PIL refuses as a decompression bomb and which killed the run.
-        # Plot only the leading dims: C(6,2)=15 pairs is already more than anyone reads, and the
-        # figure stays bounded no matter how wide the embedding is.
-        embedding_columns = embedding_columns[:_EMBEDDING_PLOT_MAX_DIMS]
+        plot_df, embedding_columns, _ = _project_embedding_columns_for_plot(
+            plot_df, embedding_columns
+        )
         dim_pairs = list(itertools.combinations(embedding_columns, 2))
         if not dim_pairs:
             return None
@@ -489,16 +546,17 @@ class BaseMultisubjectTrainer(ModelTrainer):
         embedding_columns = [
             column for column in plot_df.columns if column.startswith("embedding_")
         ]
-        # Same O(dim^2) blow-up as the embedding state-space plot above, but worse: this figure
-        # stacks a per-subject block under every dim pair, so a 64-dim embedding reached 1.69 GP
-        # and PIL rejected it as a decompression bomb. Cap the dims here too.
-        embedding_columns = embedding_columns[:_EMBEDDING_PLOT_MAX_DIMS]
         if len(embedding_columns) < 2:
             logger.info(
                 "Skipping session-context state-space plot because subject_embedding_size < 2."
             )
             return None
 
+        # Same O(dim^2) blow-up as the embedding state-space plot above, but worse: this figure
+        # repeats the whole pair grid PER SUBJECT, so a 64-dim embedding reached 1.69 GP.
+        plot_df, embedding_columns, project_embedding = _project_embedding_columns_for_plot(
+            plot_df, embedding_columns
+        )
         dim_pairs = list(itertools.combinations(embedding_columns, 2))
         ncols = min(3, len(dim_pairs))
         block_rows = int(np.ceil(len(dim_pairs) / ncols))
@@ -574,11 +632,15 @@ class BaseMultisubjectTrainer(ModelTrainer):
                         alpha=0.95,
                         zorder=2,
                     )
-                x_dim = int(x_column.split("_")[-1]) - 1
-                y_dim = int(y_column.split("_")[-1]) - 1
+                # The star is the subject's base embedding. It must go through the SAME
+                # projection as the session points around it -- indexing raw dims by the column
+                # name would put it in a different space entirely once we plot PCs.
+                projected_subject_embedding = project_embedding(subject_embedding)
+                x_dim = embedding_columns.index(x_column)
+                y_dim = embedding_columns.index(y_column)
                 ax.scatter(
-                    float(subject_embedding[x_dim]),
-                    float(subject_embedding[y_dim]),
+                    float(projected_subject_embedding[x_dim]),
+                    float(projected_subject_embedding[y_dim]),
                     marker="*",
                     s=160,
                     c="black",

--- a/code/model_trainers/base_multisubject_trainer.py
+++ b/code/model_trainers/base_multisubject_trainer.py
@@ -489,6 +489,10 @@ class BaseMultisubjectTrainer(ModelTrainer):
         embedding_columns = [
             column for column in plot_df.columns if column.startswith("embedding_")
         ]
+        # Same O(dim^2) blow-up as the embedding state-space plot above, but worse: this figure
+        # stacks a per-subject block under every dim pair, so a 64-dim embedding reached 1.69 GP
+        # and PIL rejected it as a decompression bomb. Cap the dims here too.
+        embedding_columns = embedding_columns[:_EMBEDDING_PLOT_MAX_DIMS]
         if len(embedding_columns) < 2:
             logger.info(
                 "Skipping session-context state-space plot because subject_embedding_size < 2."

--- a/code/model_trainers/disrnn_trainer.py
+++ b/code/model_trainers/disrnn_trainer.py
@@ -1843,26 +1843,45 @@ class DisrnnTrainer(BaseMultisubjectTrainer):
                         "subject_session_context_state_space"
                     )
                     checkpoint_update_rules = checkpoint_plot_paths.get("update_rules", [])
+
+                    # Same guard as the warmup/final stage block above: PIL raises
+                    # DecompressionBombError while OPENING an oversized figure, so an unguarded
+                    # conversion lets a cosmetic plot kill a multi-hour training run. A figure we
+                    # cannot log is a warning, not a failed run.
+                    def _add_checkpoint_image(key: str, path: Any) -> None:
+                        try:
+                            checkpoint_plot_payload[key] = wandb.Image(str(path))
+                        except Exception as exc:  # noqa: BLE001
+                            logger.warning(
+                                "Skipping W&B image %s at checkpoint step %s (%s): %s",
+                                key,
+                                int(steps_completed),
+                                path,
+                                exc,
+                            )
+
                     if checkpoint_bottlenecks:
-                        checkpoint_plot_payload[
-                            "checkpoint/fig/bottlenecks"
-                        ] = wandb.Image(str(checkpoint_bottlenecks))
+                        _add_checkpoint_image(
+                            "checkpoint/fig/bottlenecks", checkpoint_bottlenecks
+                        )
                     if checkpoint_subject_embeddings:
-                        checkpoint_plot_payload[
-                            "checkpoint/fig/subject_embedding_state_space"
-                        ] = wandb.Image(str(checkpoint_subject_embeddings))
+                        _add_checkpoint_image(
+                            "checkpoint/fig/subject_embedding_state_space",
+                            checkpoint_subject_embeddings,
+                        )
                     if checkpoint_subject_session_context:
-                        checkpoint_plot_payload[
-                            "checkpoint/fig/subject_session_context_state_space"
-                        ] = wandb.Image(str(checkpoint_subject_session_context))
+                        _add_checkpoint_image(
+                            "checkpoint/fig/subject_session_context_state_space",
+                            checkpoint_subject_session_context,
+                        )
                     if checkpoint_choice_rule:
-                        checkpoint_plot_payload[
-                            "checkpoint/fig/choice_rule"
-                        ] = wandb.Image(str(checkpoint_choice_rule))
+                        _add_checkpoint_image(
+                            "checkpoint/fig/choice_rule", checkpoint_choice_rule
+                        )
                     for index, update_rule_path in enumerate(checkpoint_update_rules):
-                        checkpoint_plot_payload[
-                            f"checkpoint/fig/update_rule_{index}"
-                        ] = wandb.Image(str(update_rule_path))
+                        _add_checkpoint_image(
+                            f"checkpoint/fig/update_rule_{index}", update_rule_path
+                        )
                     if checkpoint_plot_payload:
                         wandb_run.log(
                             checkpoint_plot_payload,

--- a/code/tests/test_disrnn_trainer.py
+++ b/code/tests/test_disrnn_trainer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import itertools
 import shutil
 import tempfile
 import unittest
@@ -19,7 +20,11 @@ try:
     from base.types import DatasetBundle
     from data_loaders.synthetic import SyntheticCognitiveAgents
     from model_trainers.disrnn_trainer import DisrnnTrainer, _require_n_action_logits
-    from model_trainers.base_multisubject_trainer import BaseMultisubjectTrainer
+    from model_trainers.base_multisubject_trainer import (
+        BaseMultisubjectTrainer,
+        _EMBEDDING_PLOT_N_PCS,
+        _project_embedding_columns_for_plot,
+    )
     from models import MultisubjectDisRnn, MultisubjectDisRnnConfig
     from models.session_conditioning import compute_session_curriculum_lambda
     from models.subject_embedding_initialization import (
@@ -778,6 +783,62 @@ class TestDisrnnTrainer(unittest.TestCase):
         self.assertTrue(Path(output["subject_session_context_state_space_path"]).exists())
         before_warmup = output["initial_evaluations"]["before_warmup"]
         self.assertTrue(before_warmup["plot_paths"]["subject_session_context_state_space"])
+
+    def test_embedding_is_projected_to_leading_pcs_at_every_width(self):
+        """Panel count must be C(4,2)=6 per subject at ANY embedding width -- 4, 16 or 64.
+
+        6 panels is exactly what the old raw-dim grid produced at the default embedding size of
+        4, so the figure keeps its familiar shape. It is what keeps the figure readable, keeps
+        runs at different widths comparable, and keeps the images pushed to W&B constant.
+        """
+        rng = np.random.default_rng(0)
+        for n_dims in (4, 16, 64):
+            with self.subTest(subject_embedding_size=n_dims):
+                columns = [f"embedding_{index}" for index in range(n_dims)]
+                plot_df = pd.DataFrame(rng.normal(size=(50, n_dims)), columns=columns)
+
+                _, out_columns, _ = _project_embedding_columns_for_plot(plot_df, columns)
+
+                self.assertEqual(
+                    out_columns,
+                    [f"embedding_pc{index + 1}" for index in range(_EMBEDDING_PLOT_N_PCS)],
+                )
+                self.assertEqual(
+                    len(list(itertools.combinations(out_columns, 2))),
+                    6,
+                    "the panel grid must be C(4,2)=6, not C(dim,2)",
+                )
+
+    def test_embedding_projection_is_faithful(self):
+        """The PCs must actually carry the embedding's variance, not an arbitrary slice."""
+        rng = np.random.default_rng(0)
+        columns = [f"embedding_{index}" for index in range(64)]
+        # Rank-4 data in 64 dims: 4 PCs must recover essentially all of its variance.
+        plot_df = pd.DataFrame(
+            rng.normal(size=(50, 4)) @ rng.normal(size=(4, 64)), columns=columns
+        )
+
+        out_df, out_columns, _ = _project_embedding_columns_for_plot(plot_df, columns)
+
+        raw = plot_df[columns].to_numpy()
+        centered = raw - raw.mean(axis=0)
+        self.assertAlmostEqual(
+            float(np.linalg.norm(out_df[out_columns].to_numpy())),
+            float(np.linalg.norm(centered)),
+            places=6,
+        )
+
+    def test_embedding_projection_degrades_gracefully_below_four_dims(self):
+        """subject_embedding_size=2 cannot give 4 PCs -- fall back, do not crash."""
+        columns = ["embedding_0", "embedding_1"]
+        plot_df = pd.DataFrame(
+            np.random.default_rng(0).normal(size=(20, 2)), columns=columns
+        )
+
+        _, out_columns, _ = _project_embedding_columns_for_plot(plot_df, columns)
+
+        self.assertEqual(len(out_columns), 2)
+        self.assertLessEqual(len(out_columns), _EMBEDDING_PLOT_N_PCS)
 
     def test_wide_subject_embedding_state_space_plots_are_openable_by_pil(self):
         """A wide embedding must not produce a figure PIL refuses to open.

--- a/code/tests/test_disrnn_trainer.py
+++ b/code/tests/test_disrnn_trainer.py
@@ -779,6 +779,77 @@ class TestDisrnnTrainer(unittest.TestCase):
         before_warmup = output["initial_evaluations"]["before_warmup"]
         self.assertTrue(before_warmup["plot_paths"]["subject_session_context_state_space"])
 
+    def test_wide_subject_embedding_state_space_plots_are_openable_by_pil(self):
+        """A wide embedding must not produce a figure PIL refuses to open.
+
+        Both state-space plots grid every PAIR of embedding dims, so figure area grows as
+        O(dim^2). Uncapped, subject_embedding_size=64 gave a 554 MP embedding figure and a
+        1.69 GP session-context figure. wandb.Image() opens the PNG with PIL, which raises
+        DecompressionBombError above MAX_IMAGE_PIXELS -- so these cosmetic plots killed real
+        multi-hour training runs. Assert what production actually does: open them.
+        """
+        from PIL import Image as pil_image
+
+        multisubject_bundle = self._make_multisubject_bundle()
+        trainer = DisrnnTrainer(
+            architecture={
+                "multisubject": True,
+                "latent_size": 4,
+                "update_net_n_units_per_layer": 8,
+                "update_net_n_layers": 2,
+                "choice_net_n_units_per_layer": 4,
+                "choice_net_n_layers": 1,
+                "activation": "leaky_relu",
+                "subject_embedding_size": 64,
+                "session_encoding_type": "scalar",
+                "session_integration_type": "direct",
+                "session_delta_n_layers": 2,
+                "session_delta_hidden_size": 11,
+            },
+            penalties={
+                "latent_penalty": 1e-3,
+                "choice_net_latent_penalty": 1e-3,
+                "update_net_obs_penalty": 1e-3,
+                "update_net_latent_penalty": 1e-3,
+                "subject_penalty": 1e-3,
+                "update_net_subject_penalty": 1e-3,
+                "choice_net_subject_penalty": 1e-3,
+            },
+            training={
+                "lr": 1e-3,
+                "n_steps": 0,
+                "n_warmup_steps": 0,
+                "loss": "penalized_categorical",
+                "loss_param": 1.0,
+                "max_grad_norm": 1.0,
+                "checkpoint_every_n_steps": 0,
+                "checkpoint_run_heldout_eval": False,
+                "plot_choice_rule": False,
+                "plot_update_rules": False,
+                "plot_subject_index": 0,
+                "save_output_df": False,
+            },
+            output_dir=str(self.output_dir / "wide_embedding"),
+            seed=42,
+        )
+
+        output = trainer.fit(multisubject_bundle)
+
+        for key in (
+            "subject_embedding_state_space_path",
+            "subject_session_context_state_space_path",
+        ):
+            path = Path(output[key])
+            self.assertTrue(path.exists(), f"{key} was not written")
+            with pil_image.open(path) as image:
+                n_pixels = image.size[0] * image.size[1]
+            self.assertLessEqual(
+                n_pixels,
+                pil_image.MAX_IMAGE_PIXELS,
+                f"{key} is {n_pixels} px, over PIL's {pil_image.MAX_IMAGE_PIXELS} px bomb "
+                "limit -- wandb.Image() would raise DecompressionBombError and kill the run",
+            )
+
     def test_multisubject_session_conditioning_reduces_obs_size(self):
         trainer = DisrnnTrainer(
             architecture={


### PR DESCRIPTION
## What happened

Study 05's `subject-capacity` sweep needs `subject_embedding_size=64`. All six `embed=64` cells died at checkpoint step 10000 — **twice** (original launch *and* a first recovery):

```
File "/workspace/aind-disrnn-wrapper/code/model_trainers/disrnn_trainer.py", line 1857, in fit
  ] = wandb.Image(str(checkpoint_subject_session_context))
PIL.Image.DecompressionBombError: Image size (1687392000 pixels) exceeds limit of
178956970 pixels, could be decompression bomb DOS attack.
```

This is the **exact failure mode #58 was supposed to eliminate**. #58 was a half-fix: `disrnn_trainer` has two near-duplicate plotting blocks, and #58 only fixed one of each pair.

| | dim handling | `wandb.Image` guarded |
|---|---|---|
| `_plot_subject_embedding_state_space` / stage block | ✅ capped | ✅ `_add_image` |
| `_plot_subject_session_context_state_space` / **checkpoint block** | ❌ **uncapped** | ❌ **5 raw calls** |

## Root cause: the plot enumerates raw dim pairs

Both state-space plots draw **one panel per PAIR of embedding dims**, and the session-context one repeats that whole grid **per subject**. That is O(dim²):

| `subject_embedding_size` | panels/subject |
|---|---|
| 4 (default) | 6 |
| 16 | 120 |
| 64 | **2,016** |

At 64 the figure is 1,860 × 907,200 px — **1.69 gigapixels, a strip ~756 ft tall**. Unreadable, and PIL refuses to open it.

## The fix

1. **Guard every checkpoint image** (`try/except`, like the stage block already had). This is the load-bearing half: *a figure we cannot log must be a warning, not a dead run.* Even if a future plot blows up, training survives.
2. **Plot the leading 4 principal components instead of raw dim pairs**, at every embedding width. C(4,2) = **6 panels** — exactly what the raw grid gave at the default `embed=4`, so the figure keeps its familiar shape — but now:
   - panel count is **constant in dim** (6 at 4, 16 *and* 64);
   - the view uses **every** dim rather than an arbitrary slice (the embedding is only defined up to rotation, so "dim 3 vs dim 7" carries no meaning);
   - runs at different embedding widths become **directly comparable**;
   - **far less image data goes to W&B**, where storage is tight.
3. The subject's base embedding (black star) is projected through the **same basis** rather than indexed by raw dim — otherwise the overlay lands in a different space than the points around it.

Bottleneck metrics are unaffected — `final/bottlenecks/*_total_openness` comes from params, not from these figures.

## Verification

`5 passed` (compute node), covering:
- **`..._openable_by_pil`** — end-to-end at `embed=64`, PIL can now **open** both state-space figures (which is exactly what `wandb.Image()` does). This is the invariant #58 never checked.
- **`..._projected_to_leading_pcs_at_every_width`** — 6 panels at `embed` 4/16/64, not C(dim,2).
- **`..._projection_is_faithful`** — rank-4 data in 64 dims is fully recovered by the 4 PCs.
- **`..._degrades_gracefully_below_four_dims`** — `embed=2` falls back instead of crashing.
- the **pre-existing** session-context artifact test still passes (it caught the star-overlay bug during development).

## Why it matters beyond this sweep

Six runs × ~18 GPU-hours were lost to a decorative plot, on the *second* attempt. Guarding the conversion means this class of bug can never again cost a training run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127mCUQkekGsRtNEQPXRSw3